### PR TITLE
#2: 엔티티 클래스 생성

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,344 @@
+﻿DROP TABLE IF EXISTS `users`;
+
+CREATE TABLE `users` (
+	`id`	bigint	NOT NULL,
+	`login_id`	varchar(15)	NOT NULL,
+	`name`	varchar(20)	NOT NULL,
+	`email`	varchar(320)	NOT NULL,
+	`nickname`	varchar(15)	NOT NULL,
+	`password`	varchar(255)	NOT NULL,
+	`authority`	varchar(20)	NOT NULL,
+	`set_alarm`	boolean	NOT NULL,
+	`created_at`	Timestamp	NOT NULL,
+	`updated_at`	Timestamp	NOT NULL,
+	`deleted_at`	Timestamp	NULL
+);
+
+DROP TABLE IF EXISTS `author`;
+
+CREATE TABLE `author` (
+	`id`	bigint	NOT NULL,
+	`author_name`	varchar(20) NOT	NULL,
+	`introduction`	varchar(500)	NOT NULL,
+	`belong`	varchar(15)	NULL,
+	`created_at`	Timestamp	NOT NULL,
+	`updated_at`	Timestamp	NOT NULL,
+	`deleted_at`	Timestamp	NULL,
+	`user_id`	bigint	NOT NULL
+);
+
+DROP TABLE IF EXISTS `alarm`;
+
+CREATE TABLE `alarm` (
+	`id`	bigint	NOT NULL,
+	`check`	boolean	NOT NULL,
+	`created_at`	Timestamp	NOT NULL,
+	`deleted_at`	Timestamp	NULL,
+	`user_id`	bigint	NOT NULL,
+	`comic_id`	bigint	NOT NULL
+);
+
+DROP TABLE IF EXISTS `comic`;
+
+CREATE TABLE `comic` (
+	`id`	bigint	NOT NULL,
+	`name`	varchar(30)	NOT NULL,
+	`genre`	varchar(10)	NOT NULL,
+	`summary`	varchar(500)	NOT NULL,
+	`publish_day_of_week`	varchar(3)	NOT NULL,
+	`follower_count`	int	NOT NULL,
+	`created_at`	Timestamp	NOT NULL,
+	`updated_at`	Timestamp	NOT NULL,
+	`deleted_at`	Timestamp	NULL,
+	`author_id`	bigint	NOT NULL
+);
+
+DROP TABLE IF EXISTS `thumbnail`;
+
+CREATE TABLE `thumbnail` (
+	`id`	bigint	NOT NULL,
+	`thumbnail_type`	varchar(10)	NOT NULL,
+	`image_url`	varchar(2048)	NOT NULL,
+	`comic_id`	bigint	NOT NULL,
+	`created_at`	Timestamp	NOT NULL,
+	`updated_at`	Timestamp	NOT NULL,
+	`deleted_at`	Timestamp	NULL
+);
+
+DROP TABLE IF EXISTS `episode`;
+
+CREATE TABLE `episode` (
+	`id`	bigint	NOT NULL,
+	`title`	varchar(255) NOT	NULL,
+	`episode_number`	int	NOT NULL,
+	`content_image_url`	varchar(2048)	NOT NULL,
+	`thumbnail_url`	varchar(2048)	NOT NULL,
+	`like_count`	int	NOT NULL,
+	`comic_id`	bigint	NOT NULL,
+	`created_at`	Timestamp	NOT NULL,
+	`updated_at`	Timestamp	NOT NULL,
+	`deleted_at`	Timestamp	NULL
+);
+
+DROP TABLE IF EXISTS `follow`;
+
+CREATE TABLE `follow` (
+	`id`	bigint	NOT NULL,
+	`created_at`	Timestamp	NOT NULL,
+	`user_id`	bigint	NOT NULL,
+	`comic_id`	bigint	NOT NULL
+);
+
+DROP TABLE IF EXISTS `view`;
+
+CREATE TABLE `view` (
+	`id`	bigint	NOT NULL,
+	`user_id`	bigint	NOT NULL,
+	`episode_id`	bigint	NOT NULL,
+	`first_access_time`	Timestamp NOT NULL,
+	`last_access_time`	Timestamp NOT NULL
+);
+
+DROP TABLE IF EXISTS `comment`;
+
+CREATE TABLE `comment` (
+	`id`	bigint	NOT NULL,
+	`content`	varchar(500)	NOT NULL,
+	`parent_id`	bigint	NULL,
+	`like_count`	int	NOT NULL,
+	`visible`	boolean	NOT NULL,
+	`created_at`	Timestamp	NOT NULL,
+	`updated_at`	Timestamp	NOT NULL,
+	`deleted_at`	Timestamp	NULL,
+	`user_id`	bigint	NOT NULL,
+	`episode_id`	bigint	NOT NULL
+);
+
+DROP TABLE IF EXISTS `likes`;
+
+CREATE TABLE `likes` (
+	`id`	bigint	NOT NULL,
+	`like_type`	varchar(15)	NOT NULL,
+	`reference_id`	bigint	NOT NULL,
+	`user_id`	bigint	NOT NULL,
+	`created_at`	Timestamp	NOT NULL
+);
+
+DROP TABLE IF EXISTS `star`;
+
+CREATE TABLE `star` (
+	`id`	bigint	NOT NULL,
+	`score`	int	NOT NULL,
+	`created_at`	Timestamp	NOT NULL,
+	`updated_at`	Timestamp	NOT NULL,
+	`user_id`	bigint	NOT NULL,
+	`episode_id`	bigint	NOT NULL
+);
+
+DROP TABLE IF EXISTS `comment_hide`;
+
+CREATE TABLE `comment_hide` (
+	`id`	bigint	NOT NULL,
+	`created_at`	Timestamp	NOT NULL,
+	`deleted_at`	Timestamp	NULL,
+	`user_id`	bigint	NOT NULL,
+	`comment_id`	bigint	NOT NULL
+);
+
+DROP TABLE IF EXISTS `comment_report`;
+
+CREATE TABLE `comment_report` (
+	`id`	bigint	NOT NULL,
+	`report_reason`	varchar(50)	NULL,
+	`created_at`	Timestamp	NOT NULL,
+	`deleted_at`	Timestamp	NULL,
+	`user_id`	bigint	NOT NULL,
+	`comment_id`	bigint	NOT NULL
+);
+
+ALTER TABLE `users` ADD CONSTRAINT `PK_user` PRIMARY KEY (
+	`id`
+);
+
+ALTER TABLE `author` ADD CONSTRAINT `PK_author` PRIMARY KEY (
+	`id`
+);
+
+ALTER TABLE `alarm` ADD CONSTRAINT `PK_alarm` PRIMARY KEY (
+	`id`
+);
+
+ALTER TABLE `comic` ADD CONSTRAINT `PK_comic` PRIMARY KEY (
+	`id`
+);
+
+ALTER TABLE `thumbnail` ADD CONSTRAINT `PK_thumbnail` PRIMARY KEY (
+	`id`
+);
+
+ALTER TABLE `episode` ADD CONSTRAINT `PK_episode` PRIMARY KEY (
+	`id`
+);
+
+ALTER TABLE `follow` ADD CONSTRAINT `PK_follow` PRIMARY KEY (
+	`id`
+);
+
+ALTER TABLE `view` ADD CONSTRAINT `PK_view` PRIMARY KEY (
+	`id`
+);
+
+ALTER TABLE `comment` ADD CONSTRAINT `PK_comment` PRIMARY KEY (
+	`id`
+);
+
+ALTER TABLE `likes` ADD CONSTRAINT `PK_like` PRIMARY KEY (
+	`id`
+);
+
+ALTER TABLE `star` ADD CONSTRAINT `PK_star` PRIMARY KEY (
+	`id`
+);
+
+ALTER TABLE `comment_hide` ADD CONSTRAINT `PK_comment_hide` PRIMARY KEY (
+	`id`
+);
+
+ALTER TABLE `comment_report` ADD CONSTRAINT `PK_comment_report` PRIMARY KEY (
+	`id`
+);
+
+ALTER TABLE `author` ADD CONSTRAINT `FK_user_TO_author_1` FOREIGN KEY (
+	`user_id`
+)
+REFERENCES `users` (
+	`id`
+);
+
+ALTER TABLE `alarm` ADD CONSTRAINT `FK_users_TO_alarm_1` FOREIGN KEY (
+	`user_id`
+)
+REFERENCES `users` (
+	`id`
+);
+
+ALTER TABLE `alarm` ADD CONSTRAINT `FK_comic_TO_alarm_1` FOREIGN KEY (
+	`comic_id`
+)
+REFERENCES `comic` (
+	`id`
+);
+
+ALTER TABLE `comic` ADD CONSTRAINT `FK_author_TO_comic_1` FOREIGN KEY (
+	`author_id`
+)
+REFERENCES `author` (
+	`id`
+);
+
+ALTER TABLE `thumbnail` ADD CONSTRAINT `FK_comic_TO_comic thumbnail_1` FOREIGN KEY (
+	`comic_id`
+)
+REFERENCES `comic` (
+	`id`
+);
+
+ALTER TABLE `episode` ADD CONSTRAINT `FK_comic_TO_episode_1` FOREIGN KEY (
+	`comic_id`
+)
+REFERENCES `comic` (
+	`id`
+);
+
+ALTER TABLE `follow` ADD CONSTRAINT `FK_users_TO_follow_1` FOREIGN KEY (
+	`user_id`
+)
+REFERENCES `users` (
+	`id`
+);
+
+ALTER TABLE `follow` ADD CONSTRAINT `FK_comic_TO_follow_1` FOREIGN KEY (
+	`comic_id`
+)
+REFERENCES `comic` (
+	`id`
+);
+
+ALTER TABLE `view` ADD CONSTRAINT `FK_users_TO_view_1` FOREIGN KEY (
+	`user_id`
+)
+REFERENCES `users` (
+	`id`
+);
+
+ALTER TABLE `view` ADD CONSTRAINT `FK_episode_TO_view_1` FOREIGN KEY (
+	`episode_id`
+)
+REFERENCES `episode` (
+	`id`
+);
+
+ALTER TABLE `comment` ADD CONSTRAINT `FK_users_TO_comment_1` FOREIGN KEY (
+	`user_id`
+)
+REFERENCES `users` (
+	`id`
+);
+
+ALTER TABLE `comment` ADD CONSTRAINT `FK_episode_TO_comment_1` FOREIGN KEY (
+	`episode_id`
+)
+REFERENCES `episode` (
+	`id`
+);
+
+ALTER TABLE `likes` ADD CONSTRAINT `FK_users_TO_likes_1` FOREIGN KEY (
+	`user_id`
+)
+REFERENCES `users` (
+	`id`
+);
+
+ALTER TABLE `star` ADD CONSTRAINT `FK_users_TO_star_1` FOREIGN KEY (
+	`user_id`
+)
+REFERENCES `users` (
+	`id`
+);
+
+ALTER TABLE `star` ADD CONSTRAINT `FK_episode_TO_star_1` FOREIGN KEY (
+	`episode_id`
+)
+REFERENCES `episode` (
+	`id`
+);
+
+ALTER TABLE `comment_hide` ADD CONSTRAINT `FK_users_TO_comment_hide_1` FOREIGN KEY (
+	`user_id`
+)
+REFERENCES `users` (
+	`id`
+);
+
+ALTER TABLE `comment_hide` ADD CONSTRAINT `FK_comment_TO_comment_hide_1` FOREIGN KEY (
+	`comment_id`
+)
+REFERENCES `comment` (
+	`id`
+);
+
+ALTER TABLE `comment_report` ADD CONSTRAINT `FK_users_TO_comment_report_1` FOREIGN KEY (
+	`user_id`
+)
+REFERENCES `users` (
+	`id`
+);
+
+ALTER TABLE `comment_report` ADD CONSTRAINT `FK_comment_TO_comment_report_1` FOREIGN KEY (
+	`comment_id`
+)
+REFERENCES `comment` (
+	`id`
+);
+
+

--- a/src/main/java/com/kongtoon/WebComicsApplication.java
+++ b/src/main/java/com/kongtoon/WebComicsApplication.java
@@ -2,7 +2,9 @@ package com.kongtoon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class WebComicsApplication {
 

--- a/src/main/java/com/kongtoon/domain/BaseEntity.java
+++ b/src/main/java/com/kongtoon/domain/BaseEntity.java
@@ -1,0 +1,27 @@
+package com.kongtoon.domain;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+	@CreatedDate
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/kongtoon/domain/alarm/model/Alarm.java
+++ b/src/main/java/com/kongtoon/domain/alarm/model/Alarm.java
@@ -1,0 +1,61 @@
+package com.kongtoon.domain.alarm.model;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+import org.springframework.data.annotation.CreatedDate;
+
+import com.kongtoon.domain.comic.entity.Comic;
+import com.kongtoon.domain.user.model.User;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "alarm")
+@Where(clause = "deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE alarm SET deleted_at = NOW() WHERE id = ?")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Alarm {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "check", nullable = false)
+	private boolean check;
+
+	@CreatedDate
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "deleted_at", nullable = true)
+	private LocalDateTime deletedAt;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "comic_id", nullable = false)
+	private Comic comic;
+
+	public Alarm(User user, Comic comic) {
+		this.check = false;
+		this.user = user;
+		this.comic = comic;
+	}
+}

--- a/src/main/java/com/kongtoon/domain/author/model/Author.java
+++ b/src/main/java/com/kongtoon/domain/author/model/Author.java
@@ -1,0 +1,54 @@
+package com.kongtoon.domain.author.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import com.kongtoon.domain.BaseEntity;
+import com.kongtoon.domain.user.model.User;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "author")
+@Where(clause = "deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE author SET deleted_at = NOW() WHERE id = ?")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Author extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "author_name", length = 20, nullable = false)
+	private String authorName;
+
+	@Column(name = "introduction", length = 500, nullable = false)
+	private String introduction;
+
+	@Column(name = "belong", length = 15, nullable = true)
+	private String belong;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	public Author(String authorName, String introduction, String belong, User user) {
+		this.authorName = authorName;
+		this.introduction = introduction;
+		this.belong = belong;
+		this.user = user;
+	}
+}

--- a/src/main/java/com/kongtoon/domain/comic/entity/Comic.java
+++ b/src/main/java/com/kongtoon/domain/comic/entity/Comic.java
@@ -1,0 +1,72 @@
+package com.kongtoon.domain.comic.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import com.kongtoon.domain.BaseEntity;
+import com.kongtoon.domain.author.model.Author;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "comic")
+@Where(clause = "deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE comic SET deleted_at = NOW() WHERE id = ?")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comic extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "name", length = 30, nullable = false)
+	private String name;
+
+	@Column(name = "genre", length = 10, nullable = false)
+	@Enumerated(EnumType.STRING)
+	private Genre genre;
+
+	@Column(name = "summary", length = 500, nullable = false)
+	private String summary;
+
+	@Column(name = "publish_day_of_week", length = 3, nullable = false)
+	@Enumerated(EnumType.STRING)
+	private PublishDayOfWeek publishDayOfWeek;
+
+	@Column(name = "follower_count", nullable = false)
+	private int followerCount;
+
+	@Column(name = "deleted_at", nullable = true)
+	private LocalDateTime deletedAt;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "author_id", nullable = false)
+	private Author author;
+
+	public Comic(String name, Genre genre, String summary, PublishDayOfWeek publishDayOfWeek, int followerCount,
+			Author author) {
+		this.name = name;
+		this.genre = genre;
+		this.summary = summary;
+		this.publishDayOfWeek = publishDayOfWeek;
+		this.followerCount = followerCount;
+		this.author = author;
+	}
+}

--- a/src/main/java/com/kongtoon/domain/comic/entity/Genre.java
+++ b/src/main/java/com/kongtoon/domain/comic/entity/Genre.java
@@ -1,0 +1,5 @@
+package com.kongtoon.domain.comic.entity;
+
+public enum Genre {
+	ROMANCE, FANTASY, SF, MARTIAL_ARTS, ACTIONS, ACTION, DRAMA;
+}

--- a/src/main/java/com/kongtoon/domain/comic/entity/PublishDayOfWeek.java
+++ b/src/main/java/com/kongtoon/domain/comic/entity/PublishDayOfWeek.java
@@ -1,0 +1,5 @@
+package com.kongtoon.domain.comic.entity;
+
+public enum PublishDayOfWeek {
+	MON, TUE, WED, THU, FRI, SAT, SUN;
+}

--- a/src/main/java/com/kongtoon/domain/comic/entity/Thumbnail.java
+++ b/src/main/java/com/kongtoon/domain/comic/entity/Thumbnail.java
@@ -1,0 +1,58 @@
+package com.kongtoon.domain.comic.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import com.kongtoon.domain.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "thumbnail")
+@Where(clause = "deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE thumbnail SET deleted_at = NOW() WHERE id = ?")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Thumbnail extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Enumerated(value = EnumType.STRING)
+	@Column(name = "thumbnail_type", length = 10, nullable = false)
+	private ThumbnailType thumbnailType;
+
+	@Column(name = "image_url", length = 2048, nullable = false)
+	private String imageUrl;
+
+	@Column(name = "deleted_at", nullable = true)
+	private LocalDateTime deletedAt;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "comic_id", nullable = false)
+	private Comic comic;
+
+	public Thumbnail(ThumbnailType thumbnailType, String imageUrl, LocalDateTime deletedAt, Comic comic) {
+		this.thumbnailType = thumbnailType;
+		this.imageUrl = imageUrl;
+		this.deletedAt = deletedAt;
+		this.comic = comic;
+	}
+}

--- a/src/main/java/com/kongtoon/domain/comic/entity/ThumbnailType.java
+++ b/src/main/java/com/kongtoon/domain/comic/entity/ThumbnailType.java
@@ -1,0 +1,5 @@
+package com.kongtoon.domain.comic.entity;
+
+public enum ThumbnailType {
+	SMALL, MAIN;
+}

--- a/src/main/java/com/kongtoon/domain/comment/model/Comment.java
+++ b/src/main/java/com/kongtoon/domain/comment/model/Comment.java
@@ -1,0 +1,69 @@
+package com.kongtoon.domain.comment.model;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import com.kongtoon.domain.BaseEntity;
+import com.kongtoon.domain.episode.domain.Episode;
+import com.kongtoon.domain.user.model.User;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "comment")
+@Where(clause = "deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE comment SET deleted_at = NOW() WHERE id = ?")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "content", length = 500, nullable = false)
+	private String content;
+
+	@Column(name = "parent_id", nullable = true)
+	private Long parentId;
+
+	@Column(name = "like_count", nullable = false)
+	private int likeCount;
+
+	@Column(name = "visible", nullable = false)
+	private boolean visible;
+
+	@Column(name = "deleted_at", nullable = true)
+	private LocalDateTime deletedAt;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "episode_id")
+	private Episode episode;
+
+	public Comment(String content, Long parentId, User user, Episode episode) {
+		this.likeCount = 0;
+		this.visible = true;
+		this.content = content;
+		this.parentId = parentId;
+		this.user = user;
+		this.episode = episode;
+	}
+}

--- a/src/main/java/com/kongtoon/domain/comment/model/CommentHide.java
+++ b/src/main/java/com/kongtoon/domain/comment/model/CommentHide.java
@@ -1,0 +1,56 @@
+package com.kongtoon.domain.comment.model;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+import org.springframework.data.annotation.CreatedDate;
+
+import com.kongtoon.domain.user.model.User;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "comment_hide")
+@Where(clause = "deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE comment_hide SET deleted_at = NOW() WHERE id = ?")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentHide {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@CreatedDate
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "deleted_at", nullable = true)
+	private LocalDateTime deletedAt;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "comment_id", nullable = false)
+	private Comment comment;
+
+	public CommentHide(User user, Comment comment) {
+		this.user = user;
+		this.comment = comment;
+	}
+}

--- a/src/main/java/com/kongtoon/domain/comment/model/CommentReport.java
+++ b/src/main/java/com/kongtoon/domain/comment/model/CommentReport.java
@@ -1,0 +1,62 @@
+package com.kongtoon.domain.comment.model;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+import org.springframework.data.annotation.CreatedDate;
+
+import com.kongtoon.domain.user.model.User;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "comment_report")
+@Where(clause = "deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE comment_report SET deleted_at = NOW() WHERE id = ?")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentReport {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Enumerated(value = EnumType.STRING)
+	@Column(name = "report_reason", length = 50, nullable = false)
+	private ReportReason reportReason;
+
+	@CreatedDate
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "deleted_at", nullable = true)
+	private LocalDateTime deletedAt;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "comment_id", nullable = false)
+	private Comment comment;
+
+	public CommentReport(User user, Comment comment) {
+		this.user = user;
+		this.comment = comment;
+	}
+}

--- a/src/main/java/com/kongtoon/domain/comment/model/ReportReason.java
+++ b/src/main/java/com/kongtoon/domain/comment/model/ReportReason.java
@@ -1,0 +1,12 @@
+package com.kongtoon.domain.comment.model;
+
+public enum ReportReason {
+	PERSON_OR_GROUP,
+	ABUSE,
+	ADVERTISEMENT,
+	DUPLICATE,
+	OFF_TOPIC,
+	INAPPROPRIATE_CONTENT,
+	OTHER,
+	;
+}

--- a/src/main/java/com/kongtoon/domain/episode/domain/Episode.java
+++ b/src/main/java/com/kongtoon/domain/episode/domain/Episode.java
@@ -1,0 +1,68 @@
+package com.kongtoon.domain.episode.domain;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import com.kongtoon.domain.BaseEntity;
+import com.kongtoon.domain.comic.entity.Comic;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "episode")
+@Where(clause = "deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE episode SET deleted_at = NOW() WHERE id = ?")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Episode extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "title", length = 255, nullable = false)
+	private String title;
+
+	@Column(name = "episode_number", nullable = false)
+	private int episodeNumber;
+
+	@Column(name = "content_image_url", length = 2048, nullable = false)
+	private String contentImageUrl;
+
+	@Column(name = "thumbnail_url", length = 2048, nullable = false)
+	private String thumbnailUrl;
+
+	@Column(name = "like_count", nullable = false)
+	private int likeCount;
+
+	@Column(name = "deleted_at", nullable = true)
+	private LocalDateTime deletedAt;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "comic_id", nullable = false)
+	private Comic comic;
+
+	public Episode(String title, int episodeNumber, String contentImageUrl, String thumbnailUrl, int likeCount,
+			Comic comic) {
+		this.title = title;
+		this.episodeNumber = episodeNumber;
+		this.contentImageUrl = contentImageUrl;
+		this.thumbnailUrl = thumbnailUrl;
+		this.likeCount = likeCount;
+		this.comic = comic;
+	}
+}

--- a/src/main/java/com/kongtoon/domain/follow/model/Follow.java
+++ b/src/main/java/com/kongtoon/domain/follow/model/Follow.java
@@ -1,0 +1,50 @@
+package com.kongtoon.domain.follow.model;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.springframework.data.annotation.CreatedDate;
+
+import com.kongtoon.domain.comic.entity.Comic;
+import com.kongtoon.domain.user.model.User;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "follow")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Follow {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@CreatedDate
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "comic_id", nullable = false)
+	private Comic comic;
+
+	public Follow(User user, Comic comic) {
+		this.user = user;
+		this.comic = comic;
+	}
+}

--- a/src/main/java/com/kongtoon/domain/like/model/Like.java
+++ b/src/main/java/com/kongtoon/domain/like/model/Like.java
@@ -1,0 +1,55 @@
+package com.kongtoon.domain.like.model;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.springframework.data.annotation.CreatedDate;
+
+import com.kongtoon.domain.user.model.User;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "likes")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Like {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "like_type", length = 15, nullable = false)
+	private LikeType likeType;
+
+	@Column(name = "reference_id", nullable = false)
+	private Long referenceId;
+
+	@CreatedDate
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	@JoinColumn(name = "user_id", nullable = false)
+	@ManyToOne(fetch = FetchType.LAZY)
+	private User user;
+
+	public Like(LikeType likeType, Long referenceId, User user) {
+		this.likeType = likeType;
+		this.referenceId = referenceId;
+		this.user = user;
+	}
+}

--- a/src/main/java/com/kongtoon/domain/like/model/LikeType.java
+++ b/src/main/java/com/kongtoon/domain/like/model/LikeType.java
@@ -1,0 +1,5 @@
+package com.kongtoon.domain.like.model;
+
+public enum LikeType {
+	EPISODE, COMMENT;
+}

--- a/src/main/java/com/kongtoon/domain/star/model/Star.java
+++ b/src/main/java/com/kongtoon/domain/star/model/Star.java
@@ -1,0 +1,47 @@
+package com.kongtoon.domain.star.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import com.kongtoon.domain.BaseEntity;
+import com.kongtoon.domain.episode.domain.Episode;
+import com.kongtoon.domain.user.model.User;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "star")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Star extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "score", nullable = false)
+	private int score;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "episode_id", nullable = false)
+	private Episode episode;
+
+	public Star(int score, User user, Episode episode) {
+		this.score = score;
+		this.user = user;
+		this.episode = episode;
+	}
+}

--- a/src/main/java/com/kongtoon/domain/user/model/User.java
+++ b/src/main/java/com/kongtoon/domain/user/model/User.java
@@ -1,0 +1,69 @@
+package com.kongtoon.domain.user.model;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import com.kongtoon.domain.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Where(clause = "deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE users SET deleted_at = NOW() WHERE id = ?")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "login_id", unique = true, length = 15, nullable = false)
+	private String loginId;
+
+	@Column(name = "name", length = 20, nullable = false)
+	private String name;
+
+	@Column(name = "email", unique = true, length = 320, nullable = false)
+	private String email;
+
+	@Column(name = "nickname", length = 15, nullable = false)
+	private String nickname;
+
+	@Column(name = "password", length = 255, nullable = false)
+	private String password;
+
+	@Enumerated(value = EnumType.STRING)
+	@Column(name = "authority", length = 20, nullable = false)
+	private UserAuthority authority;
+
+	@Column(name = "set_alarm", nullable = false)
+	private boolean setAlarm;
+
+	@Column(name = "deleted_at", nullable = true)
+	private LocalDateTime deletedAt;
+
+	public User(String loginId, String name, String email, String nickname, String password, UserAuthority authority,
+			boolean setAlarm) {
+		this.loginId = loginId;
+		this.name = name;
+		this.email = email;
+		this.nickname = nickname;
+		this.password = password;
+		this.authority = authority;
+		this.setAlarm = setAlarm;
+	}
+}

--- a/src/main/java/com/kongtoon/domain/user/model/UserAuthority.java
+++ b/src/main/java/com/kongtoon/domain/user/model/UserAuthority.java
@@ -1,0 +1,5 @@
+package com.kongtoon.domain.user.model;
+
+public enum UserAuthority {
+	USER, AUTHOR, ADMIN;
+}

--- a/src/main/java/com/kongtoon/domain/view/model/View.java
+++ b/src/main/java/com/kongtoon/domain/view/model/View.java
@@ -1,0 +1,55 @@
+package com.kongtoon.domain.view.model;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import com.kongtoon.domain.episode.domain.Episode;
+import com.kongtoon.domain.user.model.User;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "view")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class View {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@CreatedDate
+	@Column(name = "first_access_time", nullable = false)
+	private LocalDateTime firstAccessTime;
+
+	@LastModifiedDate
+	@Column(name = "last_access_time", nullable = false)
+	private LocalDateTime lastAccessTime;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "episode_id", nullable = false)
+	private Episode episode;
+
+	public View(User user, Episode episode) {
+		this.user = user;
+		this.episode = episode;
+	}
+}


### PR DESCRIPTION
- BaseEntity 생성
  - 대부분의 엔티티에 공통적으로 포함되는 컬럼을 하나의 컬럼에서 정의하고 상속받기 위함
  - `delete_at` 컬럼의 경우 soft delete 를 하는 엔티티에만 적용하기 위해 BaseEntity 에 명시하지 않음
- Entity 생성
  - ERD 설계에 맞게 엔티티를 생성
- init.sql 추가
  - ddl 을 담은 sql 파일