### PR TITLE
#4: 공통 예외 처리 코드 작성

### DIFF
--- a/src/main/java/com/kongtoon/common/exception/BusinessException.java
+++ b/src/main/java/com/kongtoon/common/exception/BusinessException.java
@@ -1,0 +1,13 @@
+package com.kongtoon.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public BusinessException(ErrorCode errorCode) {
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/com/kongtoon/common/exception/ErrorCode.java
+++ b/src/main/java/com/kongtoon/common/exception/ErrorCode.java
@@ -1,0 +1,17 @@
+package com.kongtoon.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+	INVALID_INPUT("잘못된 입력값입니다.", 400),
+	ENTITY_NOT_FOUND("데이터가 존재하지 않습니다.", 404);
+
+	private final String message;
+	private final int status;
+
+	ErrorCode(String message, int status) {
+		this.message = message;
+		this.status = status;
+	}
+}

--- a/src/main/java/com/kongtoon/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kongtoon/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,40 @@
+package com.kongtoon.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.kongtoon.common.exception.dto.ErrorResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(value = BusinessException.class)
+	protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException exception) {
+
+		ErrorCode errorCode = exception.getErrorCode();
+
+		return ResponseEntity
+				.status(HttpStatus.valueOf(errorCode.getStatus()))
+				.body(ErrorResponse.basic(errorCode.name(), errorCode.getMessage()));
+	}
+
+	@ExceptionHandler(value = MethodArgumentNotValidException.class)
+	protected ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException exception) {
+
+		return ResponseEntity
+				.status(HttpStatus.BAD_REQUEST)
+				.body(ErrorResponse.input(ErrorCode.INVALID_INPUT.name(), ErrorCode.INVALID_INPUT.getMessage(),
+						exception.getFieldErrors()));
+	}
+
+	@ExceptionHandler(value = Exception.class)
+	protected ResponseEntity<ErrorResponse> handleException(Exception exception) {
+
+		return ResponseEntity
+				.status(HttpStatus.INTERNAL_SERVER_ERROR)
+				.body(ErrorResponse.basic("code", exception.getMessage()));
+	}
+}

--- a/src/main/java/com/kongtoon/common/exception/dto/ErrorResponse.java
+++ b/src/main/java/com/kongtoon/common/exception/dto/ErrorResponse.java
@@ -1,0 +1,51 @@
+package com.kongtoon.common.exception.dto;
+
+import java.util.List;
+
+import org.springframework.validation.FieldError;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+
+	private final String code;
+	private final String message;
+	private final List<InputError> inputErrors;
+
+	private ErrorResponse(String code, String message) {
+		this.code = code;
+		this.message = message;
+		this.inputErrors = null;
+	}
+
+	private ErrorResponse(String code, String message, List<InputError> inputErrors) {
+		this.code = code;
+		this.message = message;
+		this.inputErrors = inputErrors;
+	}
+
+	public static ErrorResponse basic(String code, String message) {
+		return new ErrorResponse(code, message);
+	}
+
+	public static ErrorResponse input(String code, String message, List<FieldError> filedErrors) {
+		List<InputError> inputErrors = getInputErrors(filedErrors);
+
+		return new ErrorResponse(code, message, inputErrors);
+	}
+
+	private static List<InputError> getInputErrors(List<FieldError> filedErrors) {
+		return filedErrors.stream()
+				.map(fieldError -> new InputError(fieldError.getDefaultMessage(), fieldError.getField()))
+				.toList();
+	}
+
+	@Getter
+	@AllArgsConstructor
+	static class InputError {
+		private final String message;
+		private final String field;
+	}
+}


### PR DESCRIPTION
feat: 공통 예외 처리 코드 작성

- 예외가 발생했을 때 프론트엔드에게 적절한 예외 응답을 반환해주기 위함
- 기준
  - 상황에 맞는 친절한 예외 메세지
  - 예외별로 알맞은 HttpStatus 반환