### PR TITLE
#6: 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // BCrypt
+    implementation 'org.mindrot:jbcrypt:0.4'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kongtoon/common/exception/ErrorCode.java
+++ b/src/main/java/com/kongtoon/common/exception/ErrorCode.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
 	INVALID_INPUT("잘못된 입력값입니다.", 400),
-	ENTITY_NOT_FOUND("데이터가 존재하지 않습니다.", 404);
+	USER_NOT_FOUND("존재하지 않는 유저입니다.", 404),
+	LOGIN_FAIL("아이디/비밀번호를 확인해주세요.", 409);
 
 	private final String message;
 	private final int status;

--- a/src/main/java/com/kongtoon/common/security/BCryptPasswordEncoder.java
+++ b/src/main/java/com/kongtoon/common/security/BCryptPasswordEncoder.java
@@ -1,0 +1,16 @@
+package com.kongtoon.common.security;
+
+import org.mindrot.jbcrypt.BCrypt;
+
+public class BCryptPasswordEncoder implements PasswordEncoder {
+
+	@Override
+	public String encrypt(String password) {
+		return BCrypt.hashpw(password, BCrypt.gensalt());
+	}
+
+	@Override
+	public boolean isMatch(String inputPassword, String savedPassword) {
+		return BCrypt.checkpw(inputPassword, savedPassword);
+	}
+}

--- a/src/main/java/com/kongtoon/common/security/PasswordEncoder.java
+++ b/src/main/java/com/kongtoon/common/security/PasswordEncoder.java
@@ -1,0 +1,8 @@
+package com.kongtoon.common.security;
+
+public interface PasswordEncoder {
+
+	String encrypt(String password);
+
+	boolean isMatch(String inputPassword, String savedPassword);
+}

--- a/src/main/java/com/kongtoon/common/security/SecurityConfig.java
+++ b/src/main/java/com/kongtoon/common/security/SecurityConfig.java
@@ -1,0 +1,13 @@
+package com.kongtoon.common.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SecurityConfig {
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+}

--- a/src/main/java/com/kongtoon/common/session/UserSessionUtil.java
+++ b/src/main/java/com/kongtoon/common/session/UserSessionUtil.java
@@ -1,0 +1,16 @@
+package com.kongtoon.common.session;
+
+import javax.servlet.http.HttpSession;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserSessionUtil {
+
+	private static final String LOGIN_MEMBER_ID = "LOGIN_MEMBER_ID";
+
+	public static void setLoginMember(HttpSession session, String loginId) {
+		session.setAttribute(LOGIN_MEMBER_ID, loginId);
+	}
+}

--- a/src/main/java/com/kongtoon/domain/user/controller/UserController.java
+++ b/src/main/java/com/kongtoon/domain/user/controller/UserController.java
@@ -1,0 +1,38 @@
+package com.kongtoon.domain.user.controller;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kongtoon.common.session.UserSessionUtil;
+import com.kongtoon.domain.user.dto.request.LoginRequest;
+import com.kongtoon.domain.user.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+
+	private final UserService userService;
+
+	@PostMapping("/login")
+	public ResponseEntity<Void> login(
+			@RequestBody @Valid LoginRequest loginRequest,
+			HttpServletRequest httpServletRequest
+	) {
+		userService.login(loginRequest);
+
+		HttpSession session = httpServletRequest.getSession();
+		UserSessionUtil.setLoginMember(session, loginRequest.loginId());
+
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/src/main/java/com/kongtoon/domain/user/dto/request/LoginRequest.java
+++ b/src/main/java/com/kongtoon/domain/user/dto/request/LoginRequest.java
@@ -1,0 +1,10 @@
+package com.kongtoon.domain.user.dto.request;
+
+import javax.validation.constraints.NotBlank;
+
+public record LoginRequest(
+		@NotBlank
+		String loginId,
+		@NotBlank
+		String password) {
+}

--- a/src/main/java/com/kongtoon/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/kongtoon/domain/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.kongtoon.domain.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.kongtoon.domain.user.model.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+	Optional<User> findByLoginId(String loginId);
+}

--- a/src/main/java/com/kongtoon/domain/user/service/UserService.java
+++ b/src/main/java/com/kongtoon/domain/user/service/UserService.java
@@ -1,0 +1,33 @@
+package com.kongtoon.domain.user.service;
+
+import org.springframework.stereotype.Service;
+
+import com.kongtoon.common.exception.BusinessException;
+import com.kongtoon.common.exception.ErrorCode;
+import com.kongtoon.common.security.PasswordEncoder;
+import com.kongtoon.domain.user.dto.request.LoginRequest;
+import com.kongtoon.domain.user.model.User;
+import com.kongtoon.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	public void login(LoginRequest loginRequest) {
+		User user = userRepository.findByLoginId(loginRequest.loginId())
+				.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+		validatePasswordIsCorrect(loginRequest.password(), user.getPassword());
+	}
+
+	private void validatePasswordIsCorrect(String inputPassword, String originPassword) {
+		if (!passwordEncoder.isMatch(inputPassword, originPassword)) {
+			throw new BusinessException(ErrorCode.LOGIN_FAIL);
+		}
+	}
+}


### PR DESCRIPTION
- closed #6 

- jbcrypt 라이브러리 의존성 추가
  - BCrypt 암호화, 검증을 위해
- `PasswordEncoder` 인터페이스, 구현체 생성
  - `PasswordEncoder` 는 추후에 다른 암호화 방식을 사용할 수 있을 가능성에 대비하여 인터페이스로 생성
  - 추후 구현체 변경 시 설정 클래스만 변경하도록 수동 빈 등록
- UserSessionUtil 생성
  - Session 을 조작하는 로직을 캡슐화한 클래스
- 로그인 기능 구현