### PR TITLE
#12: 권한 검증 로직 구현

### DIFF
--- a/src/main/java/com/kongtoon/common/exception/ErrorCode.java
+++ b/src/main/java/com/kongtoon/common/exception/ErrorCode.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
 	INVALID_INPUT("잘못된 입력값입니다.", 400),
+	UNAUTHORIZED("인증 실패입니다.", 401),
 
 	USER_NOT_FOUND("존재하지 않는 유저입니다.", 404),
 	LOGIN_FAIL("아이디/비밀번호를 확인해주세요.", 409),

--- a/src/main/java/com/kongtoon/common/security/WebConfig.java
+++ b/src/main/java/com/kongtoon/common/security/WebConfig.java
@@ -1,0 +1,16 @@
+package com.kongtoon.common.security;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.kongtoon.common.security.interceptor.AuthenticationInterceptor;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(new AuthenticationInterceptor());
+	}
+}

--- a/src/main/java/com/kongtoon/common/security/annotation/LoginCheck.java
+++ b/src/main/java/com/kongtoon/common/security/annotation/LoginCheck.java
@@ -1,0 +1,15 @@
+package com.kongtoon.common.security.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.kongtoon.domain.user.model.UserAuthority;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginCheck {
+
+	UserAuthority authority() default UserAuthority.USER;
+}

--- a/src/main/java/com/kongtoon/common/security/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/kongtoon/common/security/interceptor/AuthenticationInterceptor.java
@@ -1,0 +1,52 @@
+package com.kongtoon.common.security.interceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.kongtoon.common.exception.BusinessException;
+import com.kongtoon.common.exception.ErrorCode;
+import com.kongtoon.common.security.annotation.LoginCheck;
+import com.kongtoon.common.session.UserSessionUtil;
+import com.kongtoon.domain.user.dto.UserAuthDTO;
+import com.kongtoon.domain.user.model.UserAuthority;
+
+@Component
+public class AuthenticationInterceptor implements HandlerInterceptor {
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+		HandlerMethod handlerMethod = (HandlerMethod)handler;
+
+		LoginCheck loginCheck = handlerMethod.getMethodAnnotation(LoginCheck.class);
+
+		if (loginCheck == null) {
+			return true;
+		}
+
+		HttpSession session = request.getSession();
+		UserAuthDTO userAuth = UserSessionUtil.getLoginUserId(session);
+
+		if (userAuth == null) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+
+		validateUserAuthority(userAuth.userAuthority(), loginCheck.authority());
+
+		return true;
+	}
+
+	private void validateUserAuthority(UserAuthority userAuthority, UserAuthority permissionAuthority) {
+		if (userAuthority == UserAuthority.ADMIN) {
+			return;
+		}
+
+		if (permissionAuthority == UserAuthority.AUTHOR && userAuthority != UserAuthority.AUTHOR) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
+	}
+}

--- a/src/main/java/com/kongtoon/common/session/UserSessionUtil.java
+++ b/src/main/java/com/kongtoon/common/session/UserSessionUtil.java
@@ -2,6 +2,8 @@ package com.kongtoon.common.session;
 
 import javax.servlet.http.HttpSession;
 
+import com.kongtoon.domain.user.dto.UserAuthDTO;
+
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -10,7 +12,11 @@ public class UserSessionUtil {
 
 	private static final String LOGIN_MEMBER_ID = "LOGIN_MEMBER_ID";
 
-	public static void setLoginMember(HttpSession session, String loginId) {
-		session.setAttribute(LOGIN_MEMBER_ID, loginId);
+	public static void setLoginUserAuth(HttpSession session, UserAuthDTO userAuth) {
+		session.setAttribute(LOGIN_MEMBER_ID, userAuth);
+	}
+
+	public static UserAuthDTO getLoginUserId(HttpSession session) {
+		return (UserAuthDTO)session.getAttribute(LOGIN_MEMBER_ID);
 	}
 }

--- a/src/main/java/com/kongtoon/domain/user/controller/UserController.java
+++ b/src/main/java/com/kongtoon/domain/user/controller/UserController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kongtoon.common.session.UserSessionUtil;
+import com.kongtoon.domain.user.dto.UserAuthDTO;
 import com.kongtoon.domain.user.dto.request.LoginRequest;
 import com.kongtoon.domain.user.dto.request.SignupRequest;
 import com.kongtoon.domain.user.service.UserService;
@@ -37,10 +38,10 @@ public class UserController {
 			@RequestBody @Valid LoginRequest loginRequest,
 			HttpServletRequest httpServletRequest
 	) {
-		userService.login(loginRequest);
+		UserAuthDTO userAuth = userService.login(loginRequest);
 
 		HttpSession session = httpServletRequest.getSession();
-		UserSessionUtil.setLoginMember(session, loginRequest.loginId());
+		UserSessionUtil.setLoginUserAuth(session, userAuth);
 
 		return ResponseEntity.noContent().build();
 	}

--- a/src/main/java/com/kongtoon/domain/user/dto/UserAuthDTO.java
+++ b/src/main/java/com/kongtoon/domain/user/dto/UserAuthDTO.java
@@ -1,0 +1,10 @@
+package com.kongtoon.domain.user.dto;
+
+import com.kongtoon.domain.user.model.User;
+import com.kongtoon.domain.user.model.UserAuthority;
+
+public record UserAuthDTO(String loginId, UserAuthority userAuthority) {
+	public static UserAuthDTO from(User user) {
+		return new UserAuthDTO(user.getLoginId(), user.getAuthority());
+	}
+}

--- a/src/main/java/com/kongtoon/domain/user/service/UserService.java
+++ b/src/main/java/com/kongtoon/domain/user/service/UserService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.kongtoon.common.exception.BusinessException;
 import com.kongtoon.common.exception.ErrorCode;
 import com.kongtoon.common.security.PasswordEncoder;
+import com.kongtoon.domain.user.dto.UserAuthDTO;
 import com.kongtoon.domain.user.dto.request.LoginRequest;
 import com.kongtoon.domain.user.dto.request.SignupRequest;
 import com.kongtoon.domain.user.model.User;
@@ -20,11 +21,13 @@ public class UserService {
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
 
-	public void login(LoginRequest loginRequest) {
+	public UserAuthDTO login(LoginRequest loginRequest) {
 		User user = userRepository.findByLoginId(loginRequest.loginId())
 				.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
 		validatePasswordIsCorrect(loginRequest.password(), user.getPassword());
+
+		return UserAuthDTO.from(user);
 	}
 
 	private void validatePasswordIsCorrect(String inputPassword, String originPassword) {


### PR DESCRIPTION
closed #12 

- 로그인 시 세션에 `UserAuthDTO` 저장하도록 변경
  - 사용자 권한 검증 시 세션에 담긴 정보만으로 해결하기 위함
- 인터셉터를 사용하여 사용자 권한 검증 로직 구현