### PR TITLE
#20: 웹툰 등록 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,4 @@ $RECYCLE.BIN/
 
 # yml
 src/main/resources/application-db.yml
+src/main/resources/application-aws.yml

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ dependencies {
 
     // BCrypt
     implementation 'org.mindrot:jbcrypt:0.4'
+
+    // S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kongtoon/WebComicsApplication.java
+++ b/src/main/java/com/kongtoon/WebComicsApplication.java
@@ -3,7 +3,9 @@ package com.kongtoon;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @EnableJpaAuditing
 @SpringBootApplication
 public class WebComicsApplication {

--- a/src/main/java/com/kongtoon/common/aws/FileStorage.java
+++ b/src/main/java/com/kongtoon/common/aws/FileStorage.java
@@ -1,0 +1,10 @@
+package com.kongtoon.common.aws;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileStorage {
+
+	String upload(MultipartFile multipartFile, FileType fileType);
+
+	void delete(String key, FileType fileType);
+}

--- a/src/main/java/com/kongtoon/common/aws/FileType.java
+++ b/src/main/java/com/kongtoon/common/aws/FileType.java
@@ -1,0 +1,5 @@
+package com.kongtoon.common.aws;
+
+public interface FileType {
+	String getPath();
+}

--- a/src/main/java/com/kongtoon/common/aws/ImageFileType.java
+++ b/src/main/java/com/kongtoon/common/aws/ImageFileType.java
@@ -1,0 +1,17 @@
+package com.kongtoon.common.aws;
+
+import lombok.Getter;
+
+@Getter
+public enum ImageFileType implements FileType {
+	EPISODE("images/episodes/"),
+	EPISODE_THUMBNAIL("images/episode_thumbnails/"),
+	COMIC_THUMBNAIL("images/comic_thumbnails/"),
+	ETC("images/etc/");
+
+	private final String path;
+
+	ImageFileType(String path) {
+		this.path = path;
+	}
+}

--- a/src/main/java/com/kongtoon/common/aws/S3Config.java
+++ b/src/main/java/com/kongtoon/common/aws/S3Config.java
@@ -1,0 +1,34 @@
+package com.kongtoon.common.aws;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class S3Config {
+
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	@Bean
+	public AmazonS3 amazonS3() {
+		AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+		return AmazonS3ClientBuilder.standard()
+				.withCredentials(new AWSStaticCredentialsProvider(credentials))
+				.withRegion(region)
+				.build();
+	}
+}

--- a/src/main/java/com/kongtoon/common/aws/S3ImageStorage.java
+++ b/src/main/java/com/kongtoon/common/aws/S3ImageStorage.java
@@ -1,0 +1,94 @@
+package com.kongtoon.common.aws;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.kongtoon.common.exception.BusinessException;
+import com.kongtoon.common.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class S3ImageStorage implements FileStorage {
+
+	private static final String AWS_S3_ADDRESS_FORMAT = "https://s3-%s.amazonaws.com/%s/%s";
+	private static final List<String> permitExtensions = List.of("jpeg", "jpg", "png");
+
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	private final AmazonS3 amazonS3;
+
+	public String upload(MultipartFile multipartFile, FileType fileType) {
+		String originalFilename = multipartFile.getOriginalFilename();
+
+		verifyExtension(getExtension(originalFilename));
+
+		ObjectMetadata objectMetadata = new ObjectMetadata();
+		objectMetadata.setContentType(multipartFile.getContentType());
+		objectMetadata.setContentLength(multipartFile.getSize());
+
+		String key = S3KeyGenerator.makeKey(originalFilename, fileType);
+
+		try (InputStream inputStream = multipartFile.getInputStream()) {
+			amazonS3.putObject(
+					bucket,
+					key,
+					inputStream,
+					objectMetadata
+			);
+		} catch (IOException e) {
+			throw new BusinessException(ErrorCode.FILE_NOT_UPLOAD);
+		}
+
+		return getSavedFileUrl(key);
+	}
+
+	private void verifyExtension(String extension) {
+		if (!permitExtensions.contains(extension)) {
+			throw new BusinessException(ErrorCode.NOT_ALLOWED_EXTENSION);
+		}
+	}
+
+	public void delete(String fileUrl, FileType fileType) {
+		try {
+			String key = getKeyContainsPath(fileUrl, fileType);
+			amazonS3.deleteObject(bucket, key);
+		} catch (AmazonServiceException e) {
+			throw new BusinessException(ErrorCode.FILE_NOT_UPLOAD);
+		}
+	}
+
+	private String getExtension(String originalFileName) {
+		if (originalFileName == null) {
+			throw new IllegalArgumentException("파일에 확장자가 존재하지 않습니다.");
+		}
+
+		int extensionSeparatorIndex = originalFileName.lastIndexOf(".") + 1;
+
+		return originalFileName.substring(extensionSeparatorIndex);
+	}
+
+	private String getSavedFileUrl(String key) {
+		return String.format(AWS_S3_ADDRESS_FORMAT, region, bucket, key);
+	}
+
+	private String getKeyContainsPath(String fileUrl, FileType fileType) {
+		return fileType.getPath()
+				+ fileUrl.substring(
+				fileUrl.lastIndexOf("/") + 1
+		);
+	}
+}

--- a/src/main/java/com/kongtoon/common/aws/S3KeyGenerator.java
+++ b/src/main/java/com/kongtoon/common/aws/S3KeyGenerator.java
@@ -1,0 +1,22 @@
+package com.kongtoon.common.aws;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class S3KeyGenerator {
+
+	private static final String SEPARATOR = "_";
+
+	public static String makeKey(String originalFileName, FileType fileType) {
+		String currentTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH:mm:ss"));
+
+		return fileType.getPath()
+				+ currentTime
+				+ SEPARATOR
+				+ originalFileName;
+	}
+}

--- a/src/main/java/com/kongtoon/common/aws/event/FileDeleteEvent.java
+++ b/src/main/java/com/kongtoon/common/aws/event/FileDeleteEvent.java
@@ -1,0 +1,10 @@
+package com.kongtoon.common.aws.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FileDeleteEvent {
+	private final String key;
+}

--- a/src/main/java/com/kongtoon/common/aws/event/FileEventListener.java
+++ b/src/main/java/com/kongtoon/common/aws/event/FileEventListener.java
@@ -1,0 +1,24 @@
+package com.kongtoon.common.aws.event;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.kongtoon.common.aws.FileStorage;
+import com.kongtoon.common.aws.ImageFileType;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FileEventListener {
+
+	private final FileStorage fileStorage;
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
+	public void deleteFile(FileDeleteEvent fileDeleteEvent) {
+		fileStorage.delete(fileDeleteEvent.getKey(), ImageFileType.COMIC_THUMBNAIL);
+	}
+}

--- a/src/main/java/com/kongtoon/common/exception/ErrorCode.java
+++ b/src/main/java/com/kongtoon/common/exception/ErrorCode.java
@@ -13,7 +13,11 @@ public enum ErrorCode {
 	DUPLICATE_EMAIL("중복된 이메일입니다.", 409),
 	DUPLICATE_APPLY_AUTHOR_AUTHORITY("이미 작가인 유저입니다.", 409),
 
-	AUTHOR_NOT_FOUND("존재하지 않는 작가입니다.", 404);
+	AUTHOR_NOT_FOUND("존재하지 않는 작가입니다.", 404),
+
+	FILE_NOT_UPLOAD("파일 업로드에 실패했습니다.", 409),
+	FILE_NOT_DELETE("파일 삭제에 실패했습니다.", 409),
+	NOT_ALLOWED_EXTENSION("허용된 확장자가 아닙니다.", 409);
 
 	private final String message;
 	private final int status;

--- a/src/main/java/com/kongtoon/domain/author/repository/AuthorRepository.java
+++ b/src/main/java/com/kongtoon/domain/author/repository/AuthorRepository.java
@@ -1,8 +1,13 @@
 package com.kongtoon.domain.author.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.kongtoon.domain.author.model.Author;
+import com.kongtoon.domain.user.model.User;
 
 public interface AuthorRepository extends JpaRepository<Author, Long> {
+
+	Optional<Author> findByUser(User user);
 }

--- a/src/main/java/com/kongtoon/domain/comic/controller/ComicController.java
+++ b/src/main/java/com/kongtoon/domain/comic/controller/ComicController.java
@@ -1,0 +1,44 @@
+package com.kongtoon.domain.comic.controller;
+
+import java.net.URI;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.SessionAttribute;
+
+import com.kongtoon.common.security.annotation.LoginCheck;
+import com.kongtoon.common.session.UserSessionUtil;
+import com.kongtoon.domain.comic.entity.dto.request.ComicCreateRequest;
+import com.kongtoon.domain.comic.service.ComicService;
+import com.kongtoon.domain.user.dto.UserAuthDTO;
+import com.kongtoon.domain.user.model.UserAuthority;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/comics")
+@RequiredArgsConstructor
+public class ComicController {
+
+	private final ComicService comicService;
+
+	@LoginCheck(authority = UserAuthority.AUTHOR)
+	@PostMapping
+	public ResponseEntity<Void> createComic(
+			@ModelAttribute @Valid ComicCreateRequest comicCreateRequest,
+			@SessionAttribute(value = UserSessionUtil.LOGIN_MEMBER_ID, required = false) UserAuthDTO userAuth,
+			HttpServletRequest httpServletRequest
+	) {
+		Long savedComicId = comicService.createComic(comicCreateRequest, userAuth.loginId());
+
+		return ResponseEntity
+				.created(URI.create(httpServletRequest.getRequestURI() + savedComicId))
+				.build();
+	}
+}

--- a/src/main/java/com/kongtoon/domain/comic/entity/Comic.java
+++ b/src/main/java/com/kongtoon/domain/comic/entity/Comic.java
@@ -63,14 +63,13 @@ public class Comic extends BaseEntity {
 	@JoinColumn(name = "author_id", nullable = false)
 	private Author author;
 
-	public Comic(String name, Genre genre, String summary, PublishDayOfWeek publishDayOfWeek, int followerCount,
-			Author author) {
+	public Comic(String name, Genre genre, String summary, PublishDayOfWeek publishDayOfWeek, Author author) {
 		this.isComplete = false;
+		this.followerCount = 0;
 		this.name = name;
 		this.genre = genre;
 		this.summary = summary;
 		this.publishDayOfWeek = publishDayOfWeek;
-		this.followerCount = followerCount;
 		this.author = author;
 	}
 }

--- a/src/main/java/com/kongtoon/domain/comic/entity/Thumbnail.java
+++ b/src/main/java/com/kongtoon/domain/comic/entity/Thumbnail.java
@@ -49,10 +49,9 @@ public class Thumbnail extends BaseEntity {
 	@JoinColumn(name = "comic_id", nullable = false)
 	private Comic comic;
 
-	public Thumbnail(ThumbnailType thumbnailType, String imageUrl, LocalDateTime deletedAt, Comic comic) {
+	public Thumbnail(ThumbnailType thumbnailType, String imageUrl, Comic comic) {
 		this.thumbnailType = thumbnailType;
 		this.imageUrl = imageUrl;
-		this.deletedAt = deletedAt;
 		this.comic = comic;
 	}
 }

--- a/src/main/java/com/kongtoon/domain/comic/entity/dto/request/ComicCreateRequest.java
+++ b/src/main/java/com/kongtoon/domain/comic/entity/dto/request/ComicCreateRequest.java
@@ -1,0 +1,67 @@
+package com.kongtoon.domain.comic.entity.dto.request;
+
+import java.util.List;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.constraints.Length;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.kongtoon.domain.author.model.Author;
+import com.kongtoon.domain.comic.entity.Comic;
+import com.kongtoon.domain.comic.entity.Genre;
+import com.kongtoon.domain.comic.entity.PublishDayOfWeek;
+import com.kongtoon.domain.comic.entity.Thumbnail;
+import com.kongtoon.domain.comic.entity.ThumbnailType;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ComicCreateRequest {
+	@Length(min = 1, max = 30)
+	@NotBlank
+	private String comicName;
+
+	@NotNull
+	private Genre genre;
+
+	@Length(min = 1, max = 500)
+	@NotBlank
+	private String summary;
+
+	@NotNull
+	private PublishDayOfWeek publishDayOfWeek;
+
+	private List<ThumbnailCreateRequest> thumbnailCreateRequests;
+
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	public static class ThumbnailCreateRequest {
+		private ThumbnailType thumbnailType;
+		private MultipartFile thumbnailImage;
+
+		public Thumbnail toThumbnail(String thumbnailImageUrl, Comic comic) {
+			return new Thumbnail(
+					this.thumbnailType,
+					thumbnailImageUrl,
+					comic
+			);
+		}
+	}
+
+	public Comic toComic(Author author) {
+		return new Comic(
+				this.comicName,
+				this.genre,
+				this.summary,
+				this.publishDayOfWeek,
+				author
+		);
+	}
+}

--- a/src/main/java/com/kongtoon/domain/comic/service/ComicService.java
+++ b/src/main/java/com/kongtoon/domain/comic/service/ComicService.java
@@ -1,0 +1,70 @@
+package com.kongtoon.domain.comic.service;
+
+import javax.transaction.Transactional;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+import com.kongtoon.common.aws.FileStorage;
+import com.kongtoon.common.aws.ImageFileType;
+import com.kongtoon.common.aws.event.FileDeleteEvent;
+import com.kongtoon.common.exception.BusinessException;
+import com.kongtoon.common.exception.ErrorCode;
+import com.kongtoon.domain.author.model.Author;
+import com.kongtoon.domain.author.repository.AuthorRepository;
+import com.kongtoon.domain.comic.entity.Comic;
+import com.kongtoon.domain.comic.entity.Thumbnail;
+import com.kongtoon.domain.comic.entity.dto.request.ComicCreateRequest;
+import com.kongtoon.domain.comic.repository.ComicRepository;
+import com.kongtoon.domain.comic.repository.ThumbnailRepository;
+import com.kongtoon.domain.user.model.User;
+import com.kongtoon.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ComicService {
+
+	private final ComicRepository comicRepository;
+	private final UserRepository userRepository;
+	private final AuthorRepository authorRepository;
+	private final ThumbnailRepository thumbnailRepository;
+
+	private final FileStorage fileStorage;
+
+	private final ApplicationEventPublisher applicationEventPublisher;
+
+	@Transactional
+	public Long createComic(ComicCreateRequest comicCreateRequest, String loginId) {
+		User user = getUser(loginId);
+		Author author = getAuthor(user);
+
+		Comic comic = comicCreateRequest.toComic(author);
+		comicRepository.save(comic);
+
+		comicCreateRequest.thumbnailCreateRequests
+				.forEach(thumbnailCreateRequest -> {
+					String thumbnailImageUrl = fileStorage.upload(
+							thumbnailCreateRequest.getThumbnailImage(),
+							ImageFileType.COMIC_THUMBNAIL
+					);
+					Thumbnail thumbnail = thumbnailCreateRequest.toThumbnail(thumbnailImageUrl, comic);
+					thumbnailRepository.save(thumbnail);
+
+					applicationEventPublisher.publishEvent(new FileDeleteEvent(thumbnailImageUrl));
+				});
+
+		return comic.getId();
+	}
+
+	private Author getAuthor(User user) {
+		return authorRepository.findByUser(user)
+				.orElseThrow(() -> new BusinessException(ErrorCode.AUTHOR_NOT_FOUND));
+	}
+
+	private User getUser(String loginId) {
+		return userRepository.findByLoginId(loginId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    include: db
+    include: db, aws


### PR DESCRIPTION
closed #20 

- build.gradle 에 AWS 관련 의존성 추가 및 S3 연동
  - 이미지 저장을 위한 스토리지로 S3를 사용
- S3에 파일 업로드, 삭제 로직 구현
  - 파일 저장소로 S3 -> 다른 저장소로 옮겨질 것을 대비하여 `FileStorage` 인터페이스를 구현하도록 함
- 웹툰 등록 API 구현
  - 웹툰 등록 API 호출 후 S3에 이미지를 저장하고 난 뒤 에러가 발생해서 롤백해야 하는 경우를 대비하여 `TransactionalEventListener` + `@Async`를 사용하여 비동기적으로 롤백하도록 구현