### PR TITLE
#24: Comic 요청 검증 로직 추가

### DIFF
--- a/src/main/java/com/kongtoon/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kongtoon/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.kongtoon.common.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -23,6 +24,15 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(value = MethodArgumentNotValidException.class)
 	protected ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException exception) {
+
+		return ResponseEntity
+				.status(HttpStatus.BAD_REQUEST)
+				.body(ErrorResponse.input(ErrorCode.INVALID_INPUT.name(), ErrorCode.INVALID_INPUT.getMessage(),
+						exception.getFieldErrors()));
+	}
+
+	@ExceptionHandler(value = BindException.class)
+	protected ResponseEntity<ErrorResponse> handleValidationException(BindException exception) {
 
 		return ResponseEntity
 				.status(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/kongtoon/common/validation/NotEmptyFile.java
+++ b/src/main/java/com/kongtoon/common/validation/NotEmptyFile.java
@@ -1,0 +1,20 @@
+package com.kongtoon.common.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Constraint(validatedBy = NotEmptyFileValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NotEmptyFile {
+	String message() default "빈 파일을 보낼 수 없습니다.";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/kongtoon/common/validation/NotEmptyFileValidator.java
+++ b/src/main/java/com/kongtoon/common/validation/NotEmptyFileValidator.java
@@ -1,0 +1,16 @@
+package com.kongtoon.common.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+public class NotEmptyFileValidator implements ConstraintValidator<NotEmptyFile, MultipartFile> {
+
+	@Override
+	public boolean isValid(MultipartFile value, ConstraintValidatorContext context) {
+		return !value.isEmpty();
+	}
+}

--- a/src/main/java/com/kongtoon/domain/comic/entity/dto/request/ComicCreateRequest.java
+++ b/src/main/java/com/kongtoon/domain/comic/entity/dto/request/ComicCreateRequest.java
@@ -2,18 +2,22 @@ package com.kongtoon.domain.comic.entity.dto.request;
 
 import java.util.List;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 import org.hibernate.validator.constraints.Length;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.kongtoon.common.validation.NotEmptyFile;
 import com.kongtoon.domain.author.model.Author;
 import com.kongtoon.domain.comic.entity.Comic;
 import com.kongtoon.domain.comic.entity.Genre;
 import com.kongtoon.domain.comic.entity.PublishDayOfWeek;
 import com.kongtoon.domain.comic.entity.Thumbnail;
 import com.kongtoon.domain.comic.entity.ThumbnailType;
+import com.kongtoon.domain.comic.entity.validation.ComicRequestValid;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,7 +26,9 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@ComicRequestValid
 public class ComicCreateRequest {
+
 	@Length(min = 1, max = 30)
 	@NotBlank
 	private String comicName;
@@ -37,13 +43,20 @@ public class ComicCreateRequest {
 	@NotNull
 	private PublishDayOfWeek publishDayOfWeek;
 
+	@NotNull
+	@Size(min = 2, max = 2)
+	@Valid
 	private List<ThumbnailCreateRequest> thumbnailCreateRequests;
 
 	@Getter
 	@Setter
 	@NoArgsConstructor
 	public static class ThumbnailCreateRequest {
+
+		@NotNull
 		private ThumbnailType thumbnailType;
+
+		@NotEmptyFile
 		private MultipartFile thumbnailImage;
 
 		public Thumbnail toThumbnail(String thumbnailImageUrl, Comic comic) {

--- a/src/main/java/com/kongtoon/domain/comic/entity/validation/ComicRequestValid.java
+++ b/src/main/java/com/kongtoon/domain/comic/entity/validation/ComicRequestValid.java
@@ -1,0 +1,20 @@
+package com.kongtoon.domain.comic.entity.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Constraint(validatedBy = ComicRequestValidator.class)
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ComicRequestValid {
+	String message() default "Invalid request";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/kongtoon/domain/comic/entity/validation/ComicRequestValidator.java
+++ b/src/main/java/com/kongtoon/domain/comic/entity/validation/ComicRequestValidator.java
@@ -1,0 +1,65 @@
+package com.kongtoon.domain.comic.entity.validation;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import org.springframework.stereotype.Component;
+
+import com.kongtoon.domain.comic.entity.ThumbnailType;
+import com.kongtoon.domain.comic.entity.dto.request.ComicCreateRequest;
+import com.kongtoon.domain.comic.entity.dto.request.ComicCreateRequest.ThumbnailCreateRequest;
+
+@Component
+public class ComicRequestValidator implements ConstraintValidator<ComicRequestValid, ComicCreateRequest> {
+
+	private static final String THUMBNAIL_INFO_REQUEST_FIRST_FILED = "thumbnailCreateRequests[]";
+	private static final String THUMBNAIL_TYPE_REQUEST_SECOND_FILED = "thumbnailType";
+
+	private static final String NOT_HAS_ALL_THUMBNAIL_TYPES_MESSAGE = "모든 종류의 썸네일 타입을 보내야합니다.";
+
+	@Override
+	public boolean isValid(ComicCreateRequest comicCreateRequest, ConstraintValidatorContext context) {
+		boolean isValid = true;
+		List<ThumbnailCreateRequest> thumbnailCreateRequests = comicCreateRequest.getThumbnailCreateRequests();
+
+		if (!hasAllThumbnailType(thumbnailCreateRequests)) {
+			addConstraintViolation(context,
+					NOT_HAS_ALL_THUMBNAIL_TYPES_MESSAGE,
+					THUMBNAIL_INFO_REQUEST_FIRST_FILED,
+					THUMBNAIL_TYPE_REQUEST_SECOND_FILED
+			);
+			isValid = false;
+		}
+
+		return isValid;
+	}
+
+	private boolean hasAllThumbnailType(List<ThumbnailCreateRequest> thumbnailCreateRequests) {
+		Map<ThumbnailType, Long> thumbnailTypes = thumbnailCreateRequests.stream()
+				.collect(Collectors.groupingBy(ThumbnailCreateRequest::getThumbnailType, Collectors.counting()));
+
+		for (ThumbnailType thumbnailType : ThumbnailType.values()) {
+			if (!thumbnailTypes.containsKey(thumbnailType) || thumbnailTypes.get(thumbnailType) != 1) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private void addConstraintViolation(
+			ConstraintValidatorContext context,
+			String errorMessage,
+			String firstValue,
+			String secondValue
+	) {
+		context.buildConstraintViolationWithTemplate(errorMessage)
+				.addPropertyNode(firstValue)
+				.addPropertyNode(secondValue)
+				.addConstraintViolation();
+	}
+}


### PR DESCRIPTION
closed #24 

- File을 요청으로 받을 때 공통으로 사용할 `NotEmptyFileValidator`
- `Comic` 요청 시 `ThumbnailType` 이 모두 하나씩 있어야함을 검증하는 `ComicRequestValidator`