### PR TITLE
#26: 웹툰 수정 기능 구현

### DIFF
--- a/src/main/java/com/kongtoon/common/aws/FileStorage.java
+++ b/src/main/java/com/kongtoon/common/aws/FileStorage.java
@@ -6,5 +6,5 @@ public interface FileStorage {
 
 	String upload(MultipartFile multipartFile, FileType fileType);
 
-	void delete(String key, FileType fileType);
+	void delete(String fileUrl, FileType fileType);
 }

--- a/src/main/java/com/kongtoon/common/aws/event/FileDeleteAfterCommitEvent.java
+++ b/src/main/java/com/kongtoon/common/aws/event/FileDeleteAfterCommitEvent.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class FileDeleteEvent {
-	private final String key;
+public class FileDeleteAfterCommitEvent {
+	private final String fileUrl;
 }

--- a/src/main/java/com/kongtoon/common/aws/event/FileDeleteAfterRollbackEvent.java
+++ b/src/main/java/com/kongtoon/common/aws/event/FileDeleteAfterRollbackEvent.java
@@ -1,0 +1,10 @@
+package com.kongtoon.common.aws.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FileDeleteAfterRollbackEvent {
+	private final String fileUrl;
+}

--- a/src/main/java/com/kongtoon/common/aws/event/FileEventListener.java
+++ b/src/main/java/com/kongtoon/common/aws/event/FileEventListener.java
@@ -18,7 +18,13 @@ public class FileEventListener {
 
 	@Async
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
-	public void deleteFile(FileDeleteEvent fileDeleteEvent) {
-		fileStorage.delete(fileDeleteEvent.getKey(), ImageFileType.COMIC_THUMBNAIL);
+	public void deleteFileAfterRollback(FileDeleteAfterRollbackEvent fileDeleteAfterRollbackEvent) {
+		fileStorage.delete(fileDeleteAfterRollbackEvent.getFileUrl(), ImageFileType.COMIC_THUMBNAIL);
+	}
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void deleteFileAfterCommit(FileDeleteAfterCommitEvent fileDeleteAfterRollbackEvent) {
+		fileStorage.delete(fileDeleteAfterRollbackEvent.getFileUrl(), ImageFileType.COMIC_THUMBNAIL);
 	}
 }

--- a/src/main/java/com/kongtoon/common/exception/ErrorCode.java
+++ b/src/main/java/com/kongtoon/common/exception/ErrorCode.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
 	INVALID_INPUT("잘못된 입력값입니다.", 400),
-	UNAUTHORIZED("인증 실패입니다.", 401),
+	AUTHENTICATION_FAIL("인증 실패입니다.", 401),
+	UNAUTHORIZED("권한이 없습니다.", 403),
 
 	USER_NOT_FOUND("존재하지 않는 유저입니다.", 404),
 	LOGIN_FAIL("아이디/비밀번호를 확인해주세요.", 409),
@@ -14,6 +15,9 @@ public enum ErrorCode {
 	DUPLICATE_APPLY_AUTHOR_AUTHORITY("이미 작가인 유저입니다.", 409),
 
 	AUTHOR_NOT_FOUND("존재하지 않는 작가입니다.", 404),
+
+	COMIC_NOT_FOUND("존재하지 않는 웹툰입니다.", 404),
+	NOT_EXISTS_THUMBNAIL_TYPE("존재하지 않는 썸네일 타입입니다.", 404),
 
 	FILE_NOT_UPLOAD("파일 업로드에 실패했습니다.", 409),
 	FILE_NOT_DELETE("파일 삭제에 실패했습니다.", 409),

--- a/src/main/java/com/kongtoon/domain/author/model/Author.java
+++ b/src/main/java/com/kongtoon/domain/author/model/Author.java
@@ -1,5 +1,7 @@
 package com.kongtoon.domain.author.model;
 
+import java.util.Objects;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -50,5 +52,9 @@ public class Author extends BaseEntity {
 		this.introduction = introduction;
 		this.belong = belong;
 		this.user = user;
+	}
+
+	public boolean isDifferenceUser(User user) {
+		return !Objects.equals(this.user.getId(), user.getId());
 	}
 }

--- a/src/main/java/com/kongtoon/domain/comic/controller/ComicController.java
+++ b/src/main/java/com/kongtoon/domain/comic/controller/ComicController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.SessionAttribute;
 
 import com.kongtoon.common.security.annotation.LoginCheck;
 import com.kongtoon.common.session.UserSessionUtil;
-import com.kongtoon.domain.comic.entity.dto.request.ComicCreateRequest;
+import com.kongtoon.domain.comic.entity.dto.request.ComicRequest;
 import com.kongtoon.domain.comic.service.ComicService;
 import com.kongtoon.domain.user.dto.UserAuthDTO;
 import com.kongtoon.domain.user.model.UserAuthority;
@@ -31,11 +31,11 @@ public class ComicController {
 	@LoginCheck(authority = UserAuthority.AUTHOR)
 	@PostMapping
 	public ResponseEntity<Void> createComic(
-			@ModelAttribute @Valid ComicCreateRequest comicCreateRequest,
+			@ModelAttribute @Valid ComicRequest comicRequest,
 			@SessionAttribute(value = UserSessionUtil.LOGIN_MEMBER_ID, required = false) UserAuthDTO userAuth,
 			HttpServletRequest httpServletRequest
 	) {
-		Long savedComicId = comicService.createComic(comicCreateRequest, userAuth.loginId());
+		Long savedComicId = comicService.createComic(comicRequest, userAuth.loginId());
 
 		return ResponseEntity
 				.created(URI.create(httpServletRequest.getRequestURI() + savedComicId))

--- a/src/main/java/com/kongtoon/domain/comic/controller/ComicController.java
+++ b/src/main/java/com/kongtoon/domain/comic/controller/ComicController.java
@@ -7,7 +7,9 @@ import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.SessionAttribute;
@@ -40,5 +42,17 @@ public class ComicController {
 		return ResponseEntity
 				.created(URI.create(httpServletRequest.getRequestURI() + savedComicId))
 				.build();
+	}
+
+	@LoginCheck(authority = UserAuthority.AUTHOR)
+	@PutMapping("/{comicId}")
+	public ResponseEntity<Void> updateComic(
+			@PathVariable Long comicId,
+			@ModelAttribute @Valid ComicRequest comicRequest,
+			@SessionAttribute(value = UserSessionUtil.LOGIN_MEMBER_ID, required = false) UserAuthDTO userAuth
+	) {
+		comicService.updateComic(comicRequest, comicId, userAuth.loginId());
+
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/kongtoon/domain/comic/entity/Comic.java
+++ b/src/main/java/com/kongtoon/domain/comic/entity/Comic.java
@@ -72,4 +72,11 @@ public class Comic extends BaseEntity {
 		this.publishDayOfWeek = publishDayOfWeek;
 		this.author = author;
 	}
+
+	public void update(String name, Genre genre, String summary, PublishDayOfWeek publishDayOfWeek) {
+		this.name = name;
+		this.genre = genre;
+		this.summary = summary;
+		this.publishDayOfWeek = publishDayOfWeek;
+	}
 }

--- a/src/main/java/com/kongtoon/domain/comic/entity/Thumbnail.java
+++ b/src/main/java/com/kongtoon/domain/comic/entity/Thumbnail.java
@@ -54,4 +54,9 @@ public class Thumbnail extends BaseEntity {
 		this.imageUrl = imageUrl;
 		this.comic = comic;
 	}
+
+	public void update(ThumbnailType thumbnailType, String imageUrl) {
+		this.thumbnailType = thumbnailType;
+		this.imageUrl = imageUrl;
+	}
 }

--- a/src/main/java/com/kongtoon/domain/comic/entity/ThumbnailType.java
+++ b/src/main/java/com/kongtoon/domain/comic/entity/ThumbnailType.java
@@ -2,4 +2,8 @@ package com.kongtoon.domain.comic.entity;
 
 public enum ThumbnailType {
 	SMALL, MAIN;
+
+	public boolean isSameType(ThumbnailType thumbnailType) {
+		return this == thumbnailType;
+	}
 }

--- a/src/main/java/com/kongtoon/domain/comic/entity/dto/request/ComicRequest.java
+++ b/src/main/java/com/kongtoon/domain/comic/entity/dto/request/ComicRequest.java
@@ -27,7 +27,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @ComicRequestValid
-public class ComicCreateRequest {
+public class ComicRequest {
 
 	@Length(min = 1, max = 30)
 	@NotBlank

--- a/src/main/java/com/kongtoon/domain/comic/entity/dto/request/ComicRequest.java
+++ b/src/main/java/com/kongtoon/domain/comic/entity/dto/request/ComicRequest.java
@@ -5,7 +5,6 @@ import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 
 import org.hibernate.validator.constraints.Length;
 import org.springframework.web.multipart.MultipartFile;
@@ -43,15 +42,14 @@ public class ComicRequest {
 	@NotNull
 	private PublishDayOfWeek publishDayOfWeek;
 
-	@NotNull
-	@Size(min = 2, max = 2)
 	@Valid
-	private List<ThumbnailCreateRequest> thumbnailCreateRequests;
+	@NotNull
+	private List<ThumbnailRequest> thumbnailRequests;
 
 	@Getter
 	@Setter
 	@NoArgsConstructor
-	public static class ThumbnailCreateRequest {
+	public static class ThumbnailRequest {
 
 		@NotNull
 		private ThumbnailType thumbnailType;

--- a/src/main/java/com/kongtoon/domain/comic/entity/validation/ComicRequestValidator.java
+++ b/src/main/java/com/kongtoon/domain/comic/entity/validation/ComicRequestValidator.java
@@ -10,11 +10,11 @@ import javax.validation.ConstraintValidatorContext;
 import org.springframework.stereotype.Component;
 
 import com.kongtoon.domain.comic.entity.ThumbnailType;
-import com.kongtoon.domain.comic.entity.dto.request.ComicCreateRequest;
-import com.kongtoon.domain.comic.entity.dto.request.ComicCreateRequest.ThumbnailCreateRequest;
+import com.kongtoon.domain.comic.entity.dto.request.ComicRequest;
+import com.kongtoon.domain.comic.entity.dto.request.ComicRequest.ThumbnailCreateRequest;
 
 @Component
-public class ComicRequestValidator implements ConstraintValidator<ComicRequestValid, ComicCreateRequest> {
+public class ComicRequestValidator implements ConstraintValidator<ComicRequestValid, ComicRequest> {
 
 	private static final String THUMBNAIL_INFO_REQUEST_FIRST_FILED = "thumbnailCreateRequests[]";
 	private static final String THUMBNAIL_TYPE_REQUEST_SECOND_FILED = "thumbnailType";
@@ -22,9 +22,9 @@ public class ComicRequestValidator implements ConstraintValidator<ComicRequestVa
 	private static final String NOT_HAS_ALL_THUMBNAIL_TYPES_MESSAGE = "모든 종류의 썸네일 타입을 보내야합니다.";
 
 	@Override
-	public boolean isValid(ComicCreateRequest comicCreateRequest, ConstraintValidatorContext context) {
+	public boolean isValid(ComicRequest comicRequest, ConstraintValidatorContext context) {
 		boolean isValid = true;
-		List<ThumbnailCreateRequest> thumbnailCreateRequests = comicCreateRequest.getThumbnailCreateRequests();
+		List<ThumbnailCreateRequest> thumbnailCreateRequests = comicRequest.getThumbnailCreateRequests();
 
 		if (!hasAllThumbnailType(thumbnailCreateRequests)) {
 			addConstraintViolation(context,

--- a/src/main/java/com/kongtoon/domain/comic/entity/validation/ComicRequestValidator.java
+++ b/src/main/java/com/kongtoon/domain/comic/entity/validation/ComicRequestValidator.java
@@ -11,12 +11,12 @@ import org.springframework.stereotype.Component;
 
 import com.kongtoon.domain.comic.entity.ThumbnailType;
 import com.kongtoon.domain.comic.entity.dto.request.ComicRequest;
-import com.kongtoon.domain.comic.entity.dto.request.ComicRequest.ThumbnailCreateRequest;
+import com.kongtoon.domain.comic.entity.dto.request.ComicRequest.ThumbnailRequest;
 
 @Component
 public class ComicRequestValidator implements ConstraintValidator<ComicRequestValid, ComicRequest> {
 
-	private static final String THUMBNAIL_INFO_REQUEST_FIRST_FILED = "thumbnailCreateRequests[]";
+	private static final String THUMBNAIL_INFO_REQUEST_FIRST_FILED = "thumbnailRequests[]";
 	private static final String THUMBNAIL_TYPE_REQUEST_SECOND_FILED = "thumbnailType";
 
 	private static final String NOT_HAS_ALL_THUMBNAIL_TYPES_MESSAGE = "모든 종류의 썸네일 타입을 보내야합니다.";
@@ -24,9 +24,9 @@ public class ComicRequestValidator implements ConstraintValidator<ComicRequestVa
 	@Override
 	public boolean isValid(ComicRequest comicRequest, ConstraintValidatorContext context) {
 		boolean isValid = true;
-		List<ThumbnailCreateRequest> thumbnailCreateRequests = comicRequest.getThumbnailCreateRequests();
+		List<ThumbnailRequest> thumbnailRequests = comicRequest.getThumbnailRequests();
 
-		if (!hasAllThumbnailType(thumbnailCreateRequests)) {
+		if (!hasAllThumbnailType(thumbnailRequests)) {
 			addConstraintViolation(context,
 					NOT_HAS_ALL_THUMBNAIL_TYPES_MESSAGE,
 					THUMBNAIL_INFO_REQUEST_FIRST_FILED,
@@ -38,9 +38,9 @@ public class ComicRequestValidator implements ConstraintValidator<ComicRequestVa
 		return isValid;
 	}
 
-	private boolean hasAllThumbnailType(List<ThumbnailCreateRequest> thumbnailCreateRequests) {
-		Map<ThumbnailType, Long> thumbnailTypes = thumbnailCreateRequests.stream()
-				.collect(Collectors.groupingBy(ThumbnailCreateRequest::getThumbnailType, Collectors.counting()));
+	private boolean hasAllThumbnailType(List<ThumbnailRequest> thumbnailRequests) {
+		Map<ThumbnailType, Long> thumbnailTypes = thumbnailRequests.stream()
+				.collect(Collectors.groupingBy(ThumbnailRequest::getThumbnailType, Collectors.counting()));
 
 		for (ThumbnailType thumbnailType : ThumbnailType.values()) {
 			if (!thumbnailTypes.containsKey(thumbnailType) || thumbnailTypes.get(thumbnailType) != 1) {

--- a/src/main/java/com/kongtoon/domain/comic/repository/ComicRepository.java
+++ b/src/main/java/com/kongtoon/domain/comic/repository/ComicRepository.java
@@ -1,8 +1,10 @@
 package com.kongtoon.domain.comic.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.kongtoon.domain.author.model.Author;
 import com.kongtoon.domain.comic.entity.Comic;
@@ -10,4 +12,7 @@ import com.kongtoon.domain.comic.entity.Comic;
 public interface ComicRepository extends JpaRepository<Comic, Long> {
 
 	List<Comic> findByAuthor(Author author);
+
+	@Query("SELECT c FROM Comic c JOIN FETCH c.author WHERE c.id = :comicId")
+	Optional<Comic> findComicWithAuthor(Long comicId);
 }

--- a/src/main/java/com/kongtoon/domain/comic/repository/ThumbnailRepository.java
+++ b/src/main/java/com/kongtoon/domain/comic/repository/ThumbnailRepository.java
@@ -11,4 +11,6 @@ import com.kongtoon.domain.comic.entity.ThumbnailType;
 public interface ThumbnailRepository extends JpaRepository<Thumbnail, Long> {
 
 	List<Thumbnail> findByComicInAndThumbnailType(List<Comic> comics, ThumbnailType thumbnailType);
+
+	List<Thumbnail> findByComic(Comic comic);
 }

--- a/src/main/java/com/kongtoon/domain/comic/service/ComicService.java
+++ b/src/main/java/com/kongtoon/domain/comic/service/ComicService.java
@@ -14,7 +14,7 @@ import com.kongtoon.domain.author.model.Author;
 import com.kongtoon.domain.author.repository.AuthorRepository;
 import com.kongtoon.domain.comic.entity.Comic;
 import com.kongtoon.domain.comic.entity.Thumbnail;
-import com.kongtoon.domain.comic.entity.dto.request.ComicCreateRequest;
+import com.kongtoon.domain.comic.entity.dto.request.ComicRequest;
 import com.kongtoon.domain.comic.repository.ComicRepository;
 import com.kongtoon.domain.comic.repository.ThumbnailRepository;
 import com.kongtoon.domain.user.model.User;
@@ -36,14 +36,14 @@ public class ComicService {
 	private final ApplicationEventPublisher applicationEventPublisher;
 
 	@Transactional
-	public Long createComic(ComicCreateRequest comicCreateRequest, String loginId) {
+	public Long createComic(ComicRequest comicRequest, String loginId) {
 		User user = getUser(loginId);
 		Author author = getAuthor(user);
 
-		Comic comic = comicCreateRequest.toComic(author);
+		Comic comic = comicRequest.toComic(author);
 		comicRepository.save(comic);
 
-		comicCreateRequest.getThumbnailCreateRequests()
+		comicRequest.getThumbnailCreateRequests()
 				.forEach(thumbnailCreateRequest -> {
 					String thumbnailImageUrl = fileStorage.upload(
 							thumbnailCreateRequest.getThumbnailImage(),

--- a/src/main/java/com/kongtoon/domain/comic/service/ComicService.java
+++ b/src/main/java/com/kongtoon/domain/comic/service/ComicService.java
@@ -1,5 +1,7 @@
 package com.kongtoon.domain.comic.service;
 
+import java.util.List;
+
 import javax.transaction.Transactional;
 
 import org.springframework.context.ApplicationEventPublisher;
@@ -7,7 +9,8 @@ import org.springframework.stereotype.Service;
 
 import com.kongtoon.common.aws.FileStorage;
 import com.kongtoon.common.aws.ImageFileType;
-import com.kongtoon.common.aws.event.FileDeleteEvent;
+import com.kongtoon.common.aws.event.FileDeleteAfterCommitEvent;
+import com.kongtoon.common.aws.event.FileDeleteAfterRollbackEvent;
 import com.kongtoon.common.exception.BusinessException;
 import com.kongtoon.common.exception.ErrorCode;
 import com.kongtoon.domain.author.model.Author;
@@ -15,6 +18,7 @@ import com.kongtoon.domain.author.repository.AuthorRepository;
 import com.kongtoon.domain.comic.entity.Comic;
 import com.kongtoon.domain.comic.entity.Thumbnail;
 import com.kongtoon.domain.comic.entity.dto.request.ComicRequest;
+import com.kongtoon.domain.comic.entity.dto.request.ComicRequest.ThumbnailRequest;
 import com.kongtoon.domain.comic.repository.ComicRepository;
 import com.kongtoon.domain.comic.repository.ThumbnailRepository;
 import com.kongtoon.domain.user.model.User;
@@ -43,19 +47,64 @@ public class ComicService {
 		Comic comic = comicRequest.toComic(author);
 		comicRepository.save(comic);
 
-		comicRequest.getThumbnailCreateRequests()
-				.forEach(thumbnailCreateRequest -> {
+		comicRequest.getThumbnailRequests()
+				.forEach(thumbnailRequest -> {
 					String thumbnailImageUrl = fileStorage.upload(
-							thumbnailCreateRequest.getThumbnailImage(),
+							thumbnailRequest.getThumbnailImage(),
 							ImageFileType.COMIC_THUMBNAIL
 					);
-					Thumbnail thumbnail = thumbnailCreateRequest.toThumbnail(thumbnailImageUrl, comic);
+					Thumbnail thumbnail = thumbnailRequest.toThumbnail(thumbnailImageUrl, comic);
 					thumbnailRepository.save(thumbnail);
 
-					applicationEventPublisher.publishEvent(new FileDeleteEvent(thumbnailImageUrl));
+					applicationEventPublisher.publishEvent(new FileDeleteAfterRollbackEvent(thumbnailImageUrl));
 				});
 
 		return comic.getId();
+	}
+
+	@Transactional
+	public void updateComic(ComicRequest comicRequest, Long comicId, String loginId) {
+		User user = getUser(loginId);
+		Comic comic = getComicWithAuthor(comicId);
+		Author author = comic.getAuthor();
+
+		validateSameAuthor(author, user);
+
+		comic.update(
+				comicRequest.getComicName(),
+				comicRequest.getGenre(),
+				comicRequest.getSummary(),
+				comicRequest.getPublishDayOfWeek()
+		);
+
+		List<Thumbnail> thumbnails = thumbnailRepository.findByComic(comic);
+		List<ThumbnailRequest> thumbnailRequests = comicRequest.getThumbnailRequests();
+
+		for (ThumbnailRequest thumbnailRequest : thumbnailRequests) {
+
+			String thumbnailImageUrl = fileStorage.upload(thumbnailRequest.getThumbnailImage(),
+					ImageFileType.COMIC_THUMBNAIL);
+			applicationEventPublisher.publishEvent(new FileDeleteAfterRollbackEvent(thumbnailImageUrl));
+
+			thumbnails.stream()
+					.filter(thumbnail -> thumbnail.getThumbnailType().isSameType(thumbnailRequest.getThumbnailType()))
+					.findFirst()
+					.ifPresentOrElse(
+							thumbnail -> {
+								applicationEventPublisher.publishEvent(new FileDeleteAfterCommitEvent(thumbnail.getImageUrl()));
+								thumbnail.update(thumbnail.getThumbnailType(), thumbnailImageUrl);
+							},
+							() -> {
+								Thumbnail thumbnail = thumbnailRequest.toThumbnail(thumbnailImageUrl, comic);
+								thumbnailRepository.save(thumbnail);
+							});
+		}
+	}
+
+	private void validateSameAuthor(Author author, User user) {
+		if (author.isDifferenceUser(user)) {
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
 	}
 
 	private Author getAuthor(User user) {
@@ -66,5 +115,10 @@ public class ComicService {
 	private User getUser(String loginId) {
 		return userRepository.findByLoginId(loginId)
 				.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+	}
+
+	private Comic getComicWithAuthor(Long comicId) {
+		return comicRepository.findComicWithAuthor(comicId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.COMIC_NOT_FOUND));
 	}
 }


### PR DESCRIPTION
closed #26 

- 만약 `ThumbnailType`이 현재는 `SMALL`, `MAIN` 밖에 없지만 새로운 타입이 추가될 경우 웹툰 수정 기능을 통해 추가할 수 있다. 
  - 따라서 DB에 이미 저장되어 있는 `ThumbnailType`이 수정 요청으로 들어온 경우 `update` 해주고 S3 저장소에서 기존의 파일을 삭제해준다.
  - DB에 없는 `ThumbnailType`이 수정 요청으로 들어온 경우 새로운 타입이 추가된 것이기 때문에 S3에 업로드하고 url 을 db에 insert 한다.
  - 이 과정에서 S3 에 업로드 후 애플리케이션에서 에러가 발생하면 S3 에 업로드된 파일을 다시 삭제하는 event 가 발생하도록 처리하였다.