### PR TITLE
#30: 에피소드 수정 기능 구현

### DIFF
--- a/src/main/java/com/kongtoon/common/exception/ErrorCode.java
+++ b/src/main/java/com/kongtoon/common/exception/ErrorCode.java
@@ -19,6 +19,8 @@ public enum ErrorCode {
 	COMIC_NOT_FOUND("존재하지 않는 웹툰입니다.", 404),
 	NOT_EXISTS_THUMBNAIL_TYPE("존재하지 않는 썸네일 타입입니다.", 404),
 
+	EPISODE_NOT_FOUND("존재하지 않는 에피소드입니다.", 404),
+
 	FILE_NOT_UPLOAD("파일 업로드에 실패했습니다.", 409),
 	FILE_NOT_DELETE("파일 삭제에 실패했습니다.", 409),
 	NOT_ALLOWED_EXTENSION("허용된 확장자가 아닙니다.", 409);

--- a/src/main/java/com/kongtoon/domain/episode/controller/EpisodeController.java
+++ b/src/main/java/com/kongtoon/domain/episode/controller/EpisodeController.java
@@ -7,7 +7,9 @@ import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -42,5 +44,17 @@ public class EpisodeController {
 		return ResponseEntity
 				.created(URI.create(httpServletRequest.getRequestURI() + "/" + savedEpisodeId))
 				.build();
+	}
+
+	@LoginCheck(authority = UserAuthority.AUTHOR)
+	@PutMapping("/{episodeId}")
+	public ResponseEntity<Void> updateEpisode(
+			@PathVariable Long episodeId,
+			@ModelAttribute @Valid EpisodeRequest episodeRequest,
+			@SessionAttribute(value = UserSessionUtil.LOGIN_MEMBER_ID, required = false) UserAuthDTO userAuth
+	) {
+		episodeService.updateEpisode(episodeRequest, episodeId, userAuth.loginId());
+
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/kongtoon/domain/episode/model/Episode.java
+++ b/src/main/java/com/kongtoon/domain/episode/model/Episode.java
@@ -61,4 +61,9 @@ public class Episode extends BaseEntity {
 		this.likeCount = likeCount;
 		this.comic = comic;
 	}
+
+	public void updateEpisode(String title, String thumbnailUrl) {
+		this.title = title;
+		this.thumbnailUrl = thumbnailUrl;
+	}
 }

--- a/src/main/java/com/kongtoon/domain/episode/model/EpisodeImage.java
+++ b/src/main/java/com/kongtoon/domain/episode/model/EpisodeImage.java
@@ -46,4 +46,12 @@ public class EpisodeImage extends BaseEntity {
 		this.contentOrder = contentOrder;
 		this.episode = episode;
 	}
+
+	public boolean isSameContentOrder(int contentOrder) {
+		return this.contentOrder == contentOrder;
+	}
+
+	public void updateEpisodeImage(String contentImageUrl) {
+		this.contentImageUrl = contentImageUrl;
+	}
 }

--- a/src/main/java/com/kongtoon/domain/episode/repository/EpisodeImageRepository.java
+++ b/src/main/java/com/kongtoon/domain/episode/repository/EpisodeImageRepository.java
@@ -1,8 +1,13 @@
 package com.kongtoon.domain.episode.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.kongtoon.domain.episode.model.Episode;
 import com.kongtoon.domain.episode.model.EpisodeImage;
 
 public interface EpisodeImageRepository extends JpaRepository<EpisodeImage, Long> {
+
+	List<EpisodeImage> findByEpisode(Episode episode);
 }

--- a/src/main/java/com/kongtoon/domain/episode/repository/EpisodeRepository.java
+++ b/src/main/java/com/kongtoon/domain/episode/repository/EpisodeRepository.java
@@ -21,4 +21,12 @@ public interface EpisodeRepository extends JpaRepository<Episode, Long> {
 	List<Episode> findRecentlyEpisodesByComics(List<Comic> comics);
 
 	Optional<Episode> findFirstByComicOrderByEpisodeNumberDesc(Comic comic);
+
+	@Query(
+			"SELECT e "
+					+ "FROM Episode e "
+					+ "JOIN FETCH e.comic c "
+					+ "JOIN FETCH c.author a "
+					+ "WHERE e.id = :episodeId")
+	Optional<Episode> findByIdWithComicAndAuthor(Long episodeId);
 }


### PR DESCRIPTION
closed #30 

- 에프소드를 수정할 때 다음과 같은 절차를 가집니다.
  1. API 를 요청한 회원이 에피소드를 수정할 권한이 있는지 검증
  2. 커밋이 된다면 기존 에피소드 썸네일 이미지를 S3 에서 비동기 삭제
  3. 수정하려는 에피소드 썸네일 이미지를 S3 에 업로드
  4. 에러가 발생하여 롤백된다면 방금 업로드했던 에피소드 썸네일 이미지를 S3에서 비동기 삭제
  5. 수정이 되는 에피소드 내용 이미지가 있다면 (여기서 수정이 된다는건 순서가 같은 이미지가 요청으로 들어온 것) 수정 메소드 호출
  6. 새롭게 추가해야 하는 에피소드 내용 이미지가 있다면 생성 메소드 호출
  7. 삭제해야 하는 에피소드 내용 이미지가 있다면 삭제 메소드 호출