### PR TITLE
#34: 에피소드 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/kongtoon/domain/comic/repository/ThumbnailRepository.java
+++ b/src/main/java/com/kongtoon/domain/comic/repository/ThumbnailRepository.java
@@ -1,6 +1,7 @@
 package com.kongtoon.domain.comic.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -13,4 +14,6 @@ public interface ThumbnailRepository extends JpaRepository<Thumbnail, Long> {
 	List<Thumbnail> findByComicInAndThumbnailType(List<Comic> comics, ThumbnailType thumbnailType);
 
 	List<Thumbnail> findByComic(Comic comic);
+
+	Optional<Thumbnail> findByComicAndThumbnailType(Comic comic, ThumbnailType thumbnailType);
 }

--- a/src/main/java/com/kongtoon/domain/episode/controller/EpisodeController.java
+++ b/src/main/java/com/kongtoon/domain/episode/controller/EpisodeController.java
@@ -6,6 +6,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,7 +18,9 @@ import org.springframework.web.bind.annotation.SessionAttribute;
 import com.kongtoon.common.security.annotation.LoginCheck;
 import com.kongtoon.common.session.UserSessionUtil;
 import com.kongtoon.domain.episode.model.dto.request.EpisodeRequest;
+import com.kongtoon.domain.episode.model.dto.response.EpisodeListResponses;
 import com.kongtoon.domain.episode.service.EpisodeModifyService;
+import com.kongtoon.domain.episode.service.EpisodeReadService;
 import com.kongtoon.domain.user.dto.UserAuthDTO;
 import com.kongtoon.domain.user.model.UserAuthority;
 
@@ -28,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 public class EpisodeController {
 
 	private final EpisodeModifyService episodeModifyService;
+	private final EpisodeReadService episodeReadService;
 
 	@LoginCheck(authority = UserAuthority.AUTHOR)
 	@PostMapping("/episodes")
@@ -55,5 +59,15 @@ public class EpisodeController {
 		episodeModifyService.updateEpisode(episodeRequest, episodeId, userAuth.loginId());
 
 		return ResponseEntity.noContent().build();
+	}
+
+	@LoginCheck(authority = UserAuthority.USER)
+	@GetMapping("/comics/{comicId}/episodes")
+	public ResponseEntity<EpisodeListResponses> getEpisodes(
+			@PathVariable Long comicId,
+			@SessionAttribute(value = UserSessionUtil.LOGIN_MEMBER_ID, required = false) UserAuthDTO userAuth
+	) {
+		EpisodeListResponses episodes = episodeReadService.getEpisodes(comicId, userAuth.loginId());
+		return ResponseEntity.ok(episodes);
 	}
 }

--- a/src/main/java/com/kongtoon/domain/episode/controller/EpisodeController.java
+++ b/src/main/java/com/kongtoon/domain/episode/controller/EpisodeController.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.SessionAttribute;
@@ -18,28 +17,28 @@ import org.springframework.web.bind.annotation.SessionAttribute;
 import com.kongtoon.common.security.annotation.LoginCheck;
 import com.kongtoon.common.session.UserSessionUtil;
 import com.kongtoon.domain.episode.model.dto.request.EpisodeRequest;
-import com.kongtoon.domain.episode.service.EpisodeService;
+import com.kongtoon.domain.episode.service.EpisodeModifyService;
 import com.kongtoon.domain.user.dto.UserAuthDTO;
 import com.kongtoon.domain.user.model.UserAuthority;
 
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/episodes")
 @RequiredArgsConstructor
 public class EpisodeController {
 
-	private final EpisodeService episodeService;
+	private final EpisodeModifyService episodeModifyService;
 
 	@LoginCheck(authority = UserAuthority.AUTHOR)
-	@PostMapping
+	@PostMapping("/episodes")
 	public ResponseEntity<Void> createEpisode(
 			@RequestParam Long comicId,
 			@ModelAttribute @Valid EpisodeRequest episodeRequest,
 			@SessionAttribute(value = UserSessionUtil.LOGIN_MEMBER_ID, required = false) UserAuthDTO userAuth,
 			HttpServletRequest httpServletRequest
 	) {
-		Long savedEpisodeId = episodeService.createEpisodeAndEpisodeImage(episodeRequest, comicId, userAuth.loginId());
+		Long savedEpisodeId = episodeModifyService.createEpisodeAndEpisodeImage(episodeRequest, comicId,
+				userAuth.loginId());
 
 		return ResponseEntity
 				.created(URI.create(httpServletRequest.getRequestURI() + "/" + savedEpisodeId))
@@ -47,13 +46,13 @@ public class EpisodeController {
 	}
 
 	@LoginCheck(authority = UserAuthority.AUTHOR)
-	@PutMapping("/{episodeId}")
+	@PutMapping("/episodes/{episodeId}")
 	public ResponseEntity<Void> updateEpisode(
 			@PathVariable Long episodeId,
 			@ModelAttribute @Valid EpisodeRequest episodeRequest,
 			@SessionAttribute(value = UserSessionUtil.LOGIN_MEMBER_ID, required = false) UserAuthDTO userAuth
 	) {
-		episodeService.updateEpisode(episodeRequest, episodeId, userAuth.loginId());
+		episodeModifyService.updateEpisode(episodeRequest, episodeId, userAuth.loginId());
 
 		return ResponseEntity.noContent().build();
 	}

--- a/src/main/java/com/kongtoon/domain/episode/model/Episode.java
+++ b/src/main/java/com/kongtoon/domain/episode/model/Episode.java
@@ -66,4 +66,8 @@ public class Episode extends BaseEntity {
 		this.title = title;
 		this.thumbnailUrl = thumbnailUrl;
 	}
+
+	public boolean isSame(Episode episode) {
+		return this == episode;
+	}
 }

--- a/src/main/java/com/kongtoon/domain/episode/model/dto/response/EpisodeListResponses.java
+++ b/src/main/java/com/kongtoon/domain/episode/model/dto/response/EpisodeListResponses.java
@@ -1,0 +1,57 @@
+package com.kongtoon.domain.episode.model.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.kongtoon.domain.comic.entity.Comic;
+import com.kongtoon.domain.comic.entity.PublishDayOfWeek;
+import com.kongtoon.domain.episode.model.Episode;
+
+public record EpisodeListResponses(
+		ComicInfo comicInfo,
+		List<EpisodeListResponse> episodes
+) {
+
+	public record EpisodeListResponse(
+			Long id,
+			int episodeNumber,
+			String title,
+			@JsonFormat(pattern = "yyyy.MM.dd")
+			LocalDate serviceDate,
+			String thumbnailUrl,
+			boolean isRead
+	) {
+		public static EpisodeListResponse from(Episode episode, boolean isRead) {
+			return new EpisodeListResponse(
+					episode.getId(),
+					episode.getEpisodeNumber(),
+					episode.getTitle(),
+					episode.getCreatedAt().toLocalDate(),
+					episode.getThumbnailUrl(),
+					isRead
+			);
+		}
+	}
+
+	public record ComicInfo(
+			Long id,
+			String comicMainImageUrl,
+			String comicName,
+			String summary,
+			String authorName,
+			PublishDayOfWeek publishDayOfWeek
+	) {
+
+		public static ComicInfo from(Comic comic, String comicMainThumbnailImageUrl) {
+			return new ComicInfo(
+					comic.getId(),
+					comicMainThumbnailImageUrl,
+					comic.getName(),
+					comic.getSummary(),
+					comic.getAuthor().getAuthorName(),
+					comic.getPublishDayOfWeek()
+			);
+		}
+	}
+}

--- a/src/main/java/com/kongtoon/domain/episode/repository/EpisodeRepository.java
+++ b/src/main/java/com/kongtoon/domain/episode/repository/EpisodeRepository.java
@@ -29,4 +29,12 @@ public interface EpisodeRepository extends JpaRepository<Episode, Long> {
 					+ "JOIN FETCH c.author a "
 					+ "WHERE e.id = :episodeId")
 	Optional<Episode> findByIdWithComicAndAuthor(Long episodeId);
+
+	@Query(
+			"SELECT e "
+					+ "FROM Episode e "
+					+ "JOIN FETCH e.comic c "
+					+ "JOIN FETCH c.author "
+					+ "WHERE c.id = :comicId")
+	List<Episode> findByComicIdWithComicAndAuthor(Long comicId);
 }

--- a/src/main/java/com/kongtoon/domain/episode/service/EpisodeModifyService.java
+++ b/src/main/java/com/kongtoon/domain/episode/service/EpisodeModifyService.java
@@ -29,7 +29,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class EpisodeService {
+public class EpisodeModifyService {
 
 	private static final int FIRST_EPISODE_NUMBER = 1;
 

--- a/src/main/java/com/kongtoon/domain/episode/service/EpisodeReadService.java
+++ b/src/main/java/com/kongtoon/domain/episode/service/EpisodeReadService.java
@@ -1,0 +1,84 @@
+package com.kongtoon.domain.episode.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kongtoon.common.exception.BusinessException;
+import com.kongtoon.common.exception.ErrorCode;
+import com.kongtoon.domain.comic.entity.Comic;
+import com.kongtoon.domain.comic.entity.Thumbnail;
+import com.kongtoon.domain.comic.entity.ThumbnailType;
+import com.kongtoon.domain.comic.repository.ComicRepository;
+import com.kongtoon.domain.comic.repository.ThumbnailRepository;
+import com.kongtoon.domain.episode.model.Episode;
+import com.kongtoon.domain.episode.model.dto.response.EpisodeListResponses;
+import com.kongtoon.domain.episode.model.dto.response.EpisodeListResponses.ComicInfo;
+import com.kongtoon.domain.episode.model.dto.response.EpisodeListResponses.EpisodeListResponse;
+import com.kongtoon.domain.episode.repository.EpisodeRepository;
+import com.kongtoon.domain.user.model.User;
+import com.kongtoon.domain.user.repository.UserRepository;
+import com.kongtoon.domain.view.model.View;
+import com.kongtoon.domain.view.repository.ViewRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class EpisodeReadService {
+
+	private static final String EMPTY_MAIN_THUMBNAIL_URL = "";
+
+	private final EpisodeRepository episodeRepository;
+	private final ComicRepository comicRepository;
+	private final UserRepository userRepository;
+	private final ViewRepository viewRepository;
+	private final ThumbnailRepository thumbnailRepository;
+
+	@Transactional(readOnly = true)
+	public EpisodeListResponses getEpisodes(Long comicId, String loginId) {
+		List<Episode> episodes = episodeRepository.findByComicIdWithComicAndAuthor(comicId);
+		Comic comic = getComic(comicId);
+		User user = getUser(loginId);
+
+		List<EpisodeListResponse> episodesInfos = getEpisodeListResponses(episodes, user);
+
+		String mainThumbnailUrl = getMainThumbnailUrl(comic);
+		ComicInfo comicInfo = ComicInfo.from(comic, mainThumbnailUrl);
+
+		return new EpisodeListResponses(
+				comicInfo,
+				episodesInfos
+		);
+	}
+
+	private List<EpisodeListResponse> getEpisodeListResponses(List<Episode> episodes, User user) {
+		List<View> views = viewRepository.findByUserAndEpisodeIn(user, episodes);
+
+		return episodes.stream()
+				.map(episode -> EpisodeListResponse.from(episode, isRead(views, episode)))
+				.toList();
+	}
+
+	private boolean isRead(List<View> views, Episode episode) {
+		return views.stream()
+				.anyMatch(view -> episode.isSame(view.getEpisode()));
+	}
+
+	private Comic getComic(Long comicId) {
+		return comicRepository.findById(comicId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.COMIC_NOT_FOUND));
+	}
+
+	private User getUser(String loginId) {
+		return userRepository.findByLoginId(loginId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+	}
+
+	private String getMainThumbnailUrl(Comic comic) {
+		return thumbnailRepository.findByComicAndThumbnailType(comic, ThumbnailType.MAIN)
+				.map(Thumbnail::getImageUrl)
+				.orElse(EMPTY_MAIN_THUMBNAIL_URL);
+	}
+}

--- a/src/main/java/com/kongtoon/domain/view/repository/ViewRepository.java
+++ b/src/main/java/com/kongtoon/domain/view/repository/ViewRepository.java
@@ -1,0 +1,14 @@
+package com.kongtoon.domain.view.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.kongtoon.domain.episode.model.Episode;
+import com.kongtoon.domain.user.model.User;
+import com.kongtoon.domain.view.model.View;
+
+public interface ViewRepository extends JpaRepository<View, Long> {
+
+	List<View> findByUserAndEpisodeIn(User user, List<Episode> episodes);
+}


### PR DESCRIPTION
closed #34 

- 에피소드 목록을 조회할 때 에피소드 목록 중 이미 조회한 적 있는 에피소드는 표시해줘야 한다. 따라서 `View` 테이블에서 사용자가 조회한 웹툰의 에피소드들을 전부 가져와서 조회한 `List<Episode>`와 `List<View>`를 스트림으로 돌면서 하나씩 확인한다. 이 때 `View.getEpisode()`와 List<Episode>`에서 꺼낸 `Episode`가 같다면 조회한적 있는 에피소드이다.