### PR TITLE
#38: 에피소드 조회 시 조회수 생성 추가

### DIFF
--- a/src/main/java/com/kongtoon/domain/episode/service/EpisodeReadService.java
+++ b/src/main/java/com/kongtoon/domain/episode/service/EpisodeReadService.java
@@ -5,6 +5,7 @@ import static com.kongtoon.domain.episode.model.dto.response.EpisodeResponse.*;
 
 import java.util.List;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +34,7 @@ import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.repository.UserRepository;
 import com.kongtoon.domain.view.model.View;
 import com.kongtoon.domain.view.repository.ViewRepository;
+import com.kongtoon.domain.view.service.event.EpisodeViewedEvent;
 
 import lombok.RequiredArgsConstructor;
 
@@ -53,6 +55,8 @@ public class EpisodeReadService {
 	private final FollowRepository followRepository;
 	private final StarRepository starRepository;
 	private final CommentRepository commentRepository;
+
+	private final ApplicationEventPublisher applicationEventPublisher;
 
 	@Transactional(readOnly = true)
 	public EpisodeListResponses getEpisodes(Long comicId, String loginId) {
@@ -90,6 +94,8 @@ public class EpisodeReadService {
 		FollowResponse followResponse = getFollowInfo(user, comic);
 		StarResponse starResponse = getStarInfo(user, episode);
 		int commentCount = commentRepository.countByEpisode(episode);
+
+		applicationEventPublisher.publishEvent(new EpisodeViewedEvent(user, episode));
 
 		return EpisodeDetailResponse.from(commentCount, likeResponse, followResponse, starResponse);
 	}

--- a/src/main/java/com/kongtoon/domain/view/model/View.java
+++ b/src/main/java/com/kongtoon/domain/view/model/View.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -14,6 +15,7 @@ import javax.persistence.Table;
 
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.kongtoon.domain.episode.model.Episode;
 import com.kongtoon.domain.user.model.User;
@@ -25,6 +27,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "view")
 @Getter
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class View {
 
@@ -51,5 +54,9 @@ public class View {
 	public View(User user, Episode episode) {
 		this.user = user;
 		this.episode = episode;
+	}
+
+	public void updateLastAccessTime() {
+		this.lastAccessTime = LocalDateTime.now();
 	}
 }

--- a/src/main/java/com/kongtoon/domain/view/repository/ViewRepository.java
+++ b/src/main/java/com/kongtoon/domain/view/repository/ViewRepository.java
@@ -1,6 +1,7 @@
 package com.kongtoon.domain.view.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,4 +12,6 @@ import com.kongtoon.domain.view.model.View;
 public interface ViewRepository extends JpaRepository<View, Long> {
 
 	List<View> findByUserAndEpisodeIn(User user, List<Episode> episodes);
+
+	Optional<View> findByUserAndEpisode(User user, Episode episode);
 }

--- a/src/main/java/com/kongtoon/domain/view/service/event/EpisodeViewedEvent.java
+++ b/src/main/java/com/kongtoon/domain/view/service/event/EpisodeViewedEvent.java
@@ -1,0 +1,24 @@
+package com.kongtoon.domain.view.service.event;
+
+import com.kongtoon.domain.episode.model.Episode;
+import com.kongtoon.domain.user.model.User;
+import com.kongtoon.domain.view.model.View;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EpisodeViewedEvent {
+
+	User user;
+
+	Episode episode;
+
+	public View toView() {
+		return new View(
+				user,
+				episode
+		);
+	}
+}

--- a/src/main/java/com/kongtoon/domain/view/service/event/EpisodeViewedEventListener.java
+++ b/src/main/java/com/kongtoon/domain/view/service/event/EpisodeViewedEventListener.java
@@ -1,0 +1,42 @@
+package com.kongtoon.domain.view.service.event;
+
+import java.util.Optional;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.kongtoon.domain.episode.model.Episode;
+import com.kongtoon.domain.user.model.User;
+import com.kongtoon.domain.view.model.View;
+import com.kongtoon.domain.view.repository.ViewRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class EpisodeViewedEventListener {
+
+	private final ViewRepository viewRepository;
+
+	@Async
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@TransactionalEventListener
+	public void saveView(EpisodeViewedEvent episodeViewedEvent) {
+		User user = episodeViewedEvent.getUser();
+		Episode episode = episodeViewedEvent.getEpisode();
+
+		View view = getViewIfPresent(user, episode)
+				.orElse(episodeViewedEvent.toView());
+
+		view.updateLastAccessTime();
+
+		viewRepository.save(view);
+	}
+
+	private Optional<View> getViewIfPresent(User user, Episode episode) {
+		return viewRepository.findByUserAndEpisode(user, episode);
+	}
+}


### PR DESCRIPTION
closed #38 

- 조회수 삽입 로직을 비동기 + 이벤트로 처리해서 관심사 분리 및 에피소드 상세 조회 로직 응답 속도에 영향을 주지 않도록 했다.