### PR TITLE
#56: 실시간 인기 급상승 웹툰 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/kongtoon/common/exception/ErrorCode.java
+++ b/src/main/java/com/kongtoon/common/exception/ErrorCode.java
@@ -27,7 +27,9 @@ public enum ErrorCode {
 
 	FILE_NOT_UPLOAD("파일 업로드에 실패했습니다.", 409),
 	FILE_NOT_DELETE("파일 삭제에 실패했습니다.", 409),
-	NOT_ALLOWED_EXTENSION("허용된 확장자가 아닙니다.", 409);
+	NOT_ALLOWED_EXTENSION("허용된 확장자가 아닙니다.", 409),
+
+	INCORRECT_TIME("유효하지 않는 시간입니다.", 409);
 
 	private final String message;
 	private final int status;

--- a/src/main/java/com/kongtoon/domain/comic/controller/ComicController.java
+++ b/src/main/java/com/kongtoon/domain/comic/controller/ComicController.java
@@ -23,6 +23,7 @@ import com.kongtoon.domain.comic.model.Genre;
 import com.kongtoon.domain.comic.model.dto.request.ComicRequest;
 import com.kongtoon.domain.comic.model.dto.response.ComicByGenreResponse;
 import com.kongtoon.domain.comic.model.dto.response.ComicByNewResponse;
+import com.kongtoon.domain.comic.model.dto.response.ComicByRealtimeRankingResponse;
 import com.kongtoon.domain.comic.model.dto.response.ComicByViewRecentResponse;
 import com.kongtoon.domain.comic.service.ComicModifyService;
 import com.kongtoon.domain.comic.service.ComicReadService;
@@ -91,5 +92,13 @@ public class ComicController {
 		List<ComicByNewResponse> comicsByViewRecentResponses = comicReadService.getComicsByNew();
 
 		return ResponseEntity.ok(comicsByViewRecentResponses);
+	}
+
+	@LoginCheck(authority = UserAuthority.USER)
+	@GetMapping("/real-time/ranking")
+	public ResponseEntity<List<ComicByRealtimeRankingResponse>> getComicsByRealtimeRanking() {
+		List<ComicByRealtimeRankingResponse> comicsByRealtimeRankingResponses = comicReadService.getComicsByRealtimeRanking();
+
+		return ResponseEntity.ok(comicsByRealtimeRankingResponses);
 	}
 }

--- a/src/main/java/com/kongtoon/domain/comic/model/dto/response/ComicByRealtimeRankingResponse.java
+++ b/src/main/java/com/kongtoon/domain/comic/model/dto/response/ComicByRealtimeRankingResponse.java
@@ -1,0 +1,21 @@
+package com.kongtoon.domain.comic.model.dto.response;
+
+public record ComicByRealtimeRankingResponse(
+		Long id,
+		int rank,
+		String name,
+		String author,
+		String thumbnailUrl,
+		Long viewCount
+) {
+	public static ComicByRealtimeRankingResponse from(
+			Long id,
+			int rank,
+			String name,
+			String author,
+			String thumbnailUrl,
+			Long viewCount
+	) {
+		return new ComicByRealtimeRankingResponse(id, rank, name, author, thumbnailUrl, viewCount);
+	}
+}

--- a/src/main/java/com/kongtoon/domain/comic/model/dto/response/vo/TwoHourSlice.java
+++ b/src/main/java/com/kongtoon/domain/comic/model/dto/response/vo/TwoHourSlice.java
@@ -1,0 +1,53 @@
+package com.kongtoon.domain.comic.model.dto.response.vo;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import com.kongtoon.common.exception.BusinessException;
+import com.kongtoon.common.exception.ErrorCode;
+
+import lombok.Getter;
+
+@Getter
+public enum TwoHourSlice {
+	HOUR_00_02(LocalTime.of(0, 0), LocalTime.of(2, 0)),
+	HOUR_02_04(LocalTime.of(2, 0), LocalTime.of(4, 0)),
+	HOUR_04_06(LocalTime.of(4, 0), LocalTime.of(6, 0)),
+	HOUR_06_08(LocalTime.of(6, 0), LocalTime.of(8, 0)),
+	HOUR_08_10(LocalTime.of(8, 0), LocalTime.of(10, 0)),
+	HOUR_10_12(LocalTime.of(10, 0), LocalTime.of(12, 0)),
+	HOUR_12_14(LocalTime.of(12, 0), LocalTime.of(14, 0)),
+	HOUR_14_16(LocalTime.of(14, 0), LocalTime.of(16, 0)),
+	HOUR_16_18(LocalTime.of(16, 0), LocalTime.of(18, 0)),
+	HOUR_18_20(LocalTime.of(18, 0), LocalTime.of(20, 0)),
+	HOUR_20_22(LocalTime.of(20, 0), LocalTime.of(22, 0)),
+	HOUR_22_24(LocalTime.of(22, 0), LocalTime.of(23, 59, 59));
+
+	private final LocalTime startTime;
+	private final LocalTime endTime;
+
+	TwoHourSlice(LocalTime startTime, LocalTime endTime) {
+		this.startTime = startTime;
+		this.endTime = endTime;
+	}
+
+	public static TwoHourSlice findBeforeTimeSlice(LocalTime now) {
+		for (int i = 0; i < values().length; i++) {
+			if (now.isAfter(values()[i].startTime) && now.isBefore(values()[i].endTime)) {
+				if (values()[i] == HOUR_00_02) {
+					return HOUR_22_24;
+				}
+				return values()[i - 1];
+			}
+		}
+
+		throw new BusinessException(ErrorCode.INCORRECT_TIME);
+	}
+
+	public LocalDate getBeforeDate() {
+		if (this == HOUR_22_24) {
+			return LocalDate.now().minusDays(1);
+		}
+		return LocalDate.now();
+	}
+}

--- a/src/main/java/com/kongtoon/domain/comic/repository/ComicCustomRepository.java
+++ b/src/main/java/com/kongtoon/domain/comic/repository/ComicCustomRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.kongtoon.domain.comic.model.Genre;
 import com.kongtoon.domain.comic.model.dto.response.ComicByGenreResponse;
 import com.kongtoon.domain.comic.model.dto.response.ComicByNewResponse;
+import com.kongtoon.domain.comic.model.dto.response.ComicByRealtimeRankingResponse;
 import com.kongtoon.domain.comic.model.dto.response.ComicByViewRecentResponse;
 
 public interface ComicCustomRepository {
@@ -14,4 +15,6 @@ public interface ComicCustomRepository {
 	List<ComicByViewRecentResponse> findComicsByViewRecent(Long userId);
 
 	List<ComicByNewResponse> findComicsByNew();
+
+	List<ComicByRealtimeRankingResponse> findComicsByRealtimeRanking();
 }

--- a/src/main/java/com/kongtoon/domain/comic/service/ComicReadService.java
+++ b/src/main/java/com/kongtoon/domain/comic/service/ComicReadService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.kongtoon.domain.comic.model.Genre;
 import com.kongtoon.domain.comic.model.dto.response.ComicByGenreResponse;
 import com.kongtoon.domain.comic.model.dto.response.ComicByNewResponse;
+import com.kongtoon.domain.comic.model.dto.response.ComicByRealtimeRankingResponse;
 import com.kongtoon.domain.comic.model.dto.response.ComicByViewRecentResponse;
 import com.kongtoon.domain.comic.repository.ComicRepository;
 
@@ -35,5 +36,11 @@ public class ComicReadService {
 	public List<ComicByNewResponse> getComicsByNew() {
 
 		return comicRepository.findComicsByNew();
+	}
+
+	@Transactional(readOnly = true)
+	public List<ComicByRealtimeRankingResponse> getComicsByRealtimeRanking() {
+
+		return comicRepository.findComicsByRealtimeRanking();
 	}
 }


### PR DESCRIPTION
실시간 인기 급상승 웹툰 목록은 자정부터 2시간 씩 나누어서 조회수를 계산한다. 그리고 현재 시간에서 이전 2시간 범위(0~2, 2~4, 4~6, ... 22~24)의 누적 조회수별로 나열된다.