### PR TITLE
#58: 장르별 웹툰 목록 조회 쿼리 개선

### DIFF
--- a/src/main/java/com/kongtoon/domain/comic/model/dto/response/ComicByGenreResponse.java
+++ b/src/main/java/com/kongtoon/domain/comic/model/dto/response/ComicByGenreResponse.java
@@ -5,6 +5,7 @@ public record ComicByGenreResponse(
 		String name,
 		String author,
 		String thumbnailUrl,
-		boolean isNew
+		boolean isNew,
+		long viewCount
 ) {
 }


### PR DESCRIPTION
closed #58 

- 약 0.86초 걸리던 쿼리 -> 약 0.02초로 개선
- 상관 서브쿼리 제거 및 episode 테이블의 (comic_id, episode_number) 복합 인덱스 생성
- https://kongding0311.tistory.com/49