### PR TITLE
#60: 실시간 인기 웹툰 목록 조회 기능 리팩토링

### DIFF
--- a/src/main/java/com/kongtoon/WebComicsApplication.java
+++ b/src/main/java/com/kongtoon/WebComicsApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@SpringBootApplication
 @EnableAsync
 @EnableJpaAuditing
-@SpringBootApplication
+@EnableScheduling
 public class WebComicsApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/kongtoon/common/scheduler/RealtimeComicRankingScheduler.java
+++ b/src/main/java/com/kongtoon/common/scheduler/RealtimeComicRankingScheduler.java
@@ -1,0 +1,44 @@
+package com.kongtoon.common.scheduler;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kongtoon.domain.comic.model.RealtimeComicRanking;
+import com.kongtoon.domain.comic.model.dto.response.vo.TwoHourSlice;
+import com.kongtoon.domain.comic.repository.ComicRepository;
+import com.kongtoon.domain.comic.repository.RealtimeComicRankingRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class RealtimeComicRankingScheduler {
+
+	private final ComicRepository comicRepository;
+	private final RealtimeComicRankingRepository realtimeComicRankingRepository;
+
+	@Transactional
+	@Scheduled(cron = "0 59 1/2 * * *")
+	public void test() {
+		log.info("실시간 인기 웹툰 목록 조회 스케줄링 시작");
+
+		LocalDate recordDate = LocalDate.now();
+		TwoHourSlice recordTime = TwoHourSlice.getNow(LocalTime.now());
+
+		List<RealtimeComicRanking> realtimeComicRankings = comicRepository.findRealtimeComicRankingForSave(
+				recordDate,
+				recordTime
+		);
+
+		realtimeComicRankingRepository.saveAll(realtimeComicRankings);
+
+		log.info("실시간 인기 웹툰 목록 조회 스케줄링 종료");
+	}
+}

--- a/src/main/java/com/kongtoon/domain/comic/model/RealtimeComicRanking.java
+++ b/src/main/java/com/kongtoon/domain/comic/model/RealtimeComicRanking.java
@@ -1,0 +1,58 @@
+package com.kongtoon.domain.comic.model;
+
+import java.time.LocalDate;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import com.kongtoon.domain.BaseEntity;
+import com.kongtoon.domain.comic.model.dto.response.vo.TwoHourSlice;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "realtime_comic_ranking")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RealtimeComicRanking extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "record_date", nullable = false)
+	private LocalDate recordDate;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "record_time", nullable = false)
+	private TwoHourSlice recordTime;
+
+	@Column(name = "ranks", nullable = false)
+	private int rank;
+
+	@Column(name = "views", nullable = false)
+	private long views;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "comic_id", nullable = false)
+	private Comic comic;
+
+	public RealtimeComicRanking(LocalDate recordDate, TwoHourSlice recordTime, int rank, long views, Comic comic) {
+		this.recordDate = recordDate;
+		this.recordTime = recordTime;
+		this.rank = rank;
+		this.views = views;
+		this.comic = comic;
+	}
+}

--- a/src/main/java/com/kongtoon/domain/comic/model/dto/response/ComicByRealtimeRankingResponse.java
+++ b/src/main/java/com/kongtoon/domain/comic/model/dto/response/ComicByRealtimeRankingResponse.java
@@ -6,7 +6,7 @@ public record ComicByRealtimeRankingResponse(
 		String name,
 		String author,
 		String thumbnailUrl,
-		Long viewCount
+		Long views
 ) {
 	public static ComicByRealtimeRankingResponse from(
 			Long id,

--- a/src/main/java/com/kongtoon/domain/comic/model/dto/response/vo/TwoHourSlice.java
+++ b/src/main/java/com/kongtoon/domain/comic/model/dto/response/vo/TwoHourSlice.java
@@ -2,6 +2,7 @@ package com.kongtoon.domain.comic.model.dto.response.vo;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Arrays;
 
 import com.kongtoon.common.exception.BusinessException;
 import com.kongtoon.common.exception.ErrorCode;
@@ -31,7 +32,14 @@ public enum TwoHourSlice {
 		this.endTime = endTime;
 	}
 
-	public static TwoHourSlice findBeforeTimeSlice(LocalTime now) {
+	public LocalDate getPrevSliceDate() {
+		if (this == HOUR_22_24) {
+			return LocalDate.now().minusDays(1);
+		}
+		return LocalDate.now();
+	}
+
+	public static TwoHourSlice getPrev(LocalTime now) {
 		for (int i = 0; i < values().length; i++) {
 			if (now.isAfter(values()[i].startTime) && now.isBefore(values()[i].endTime)) {
 				if (values()[i] == HOUR_00_02) {
@@ -44,10 +52,23 @@ public enum TwoHourSlice {
 		throw new BusinessException(ErrorCode.INCORRECT_TIME);
 	}
 
-	public LocalDate getBeforeDate() {
-		if (this == HOUR_22_24) {
-			return LocalDate.now().minusDays(1);
+	public static TwoHourSlice getNow(LocalTime now) {
+		return Arrays.stream(values())
+				.filter(slice -> slice.startTime.isBefore(now) && slice.endTime.isAfter(now))
+				.findFirst()
+				.orElseThrow(() -> new BusinessException(ErrorCode.INCORRECT_TIME));
+	}
+
+	public TwoHourSlice getNext() {
+		for (int i = 0; i < values().length; i++) {
+			if (values()[i] == this) {
+				if (values()[i] == HOUR_22_24) {
+					return HOUR_00_02;
+				}
+				return values()[i + 1];
+			}
 		}
-		return LocalDate.now();
+
+		throw new BusinessException(ErrorCode.INCORRECT_TIME);
 	}
 }

--- a/src/main/java/com/kongtoon/domain/comic/repository/ComicCustomRepository.java
+++ b/src/main/java/com/kongtoon/domain/comic/repository/ComicCustomRepository.java
@@ -1,12 +1,15 @@
 package com.kongtoon.domain.comic.repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import com.kongtoon.domain.comic.model.Genre;
+import com.kongtoon.domain.comic.model.RealtimeComicRanking;
 import com.kongtoon.domain.comic.model.dto.response.ComicByGenreResponse;
 import com.kongtoon.domain.comic.model.dto.response.ComicByNewResponse;
 import com.kongtoon.domain.comic.model.dto.response.ComicByRealtimeRankingResponse;
 import com.kongtoon.domain.comic.model.dto.response.ComicByViewRecentResponse;
+import com.kongtoon.domain.comic.model.dto.response.vo.TwoHourSlice;
 
 public interface ComicCustomRepository {
 
@@ -16,5 +19,7 @@ public interface ComicCustomRepository {
 
 	List<ComicByNewResponse> findComicsByNew();
 
-	List<ComicByRealtimeRankingResponse> findComicsByRealtimeRanking();
+	List<RealtimeComicRanking> findRealtimeComicRankingForSave(LocalDate recordDate, TwoHourSlice recordTime);
+
+	List<ComicByRealtimeRankingResponse> findComicsByRealtimeRanking(LocalDate recordDate, TwoHourSlice recordTime);
 }

--- a/src/main/java/com/kongtoon/domain/comic/repository/RealtimeComicRankingRepository.java
+++ b/src/main/java/com/kongtoon/domain/comic/repository/RealtimeComicRankingRepository.java
@@ -1,0 +1,8 @@
+package com.kongtoon.domain.comic.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.kongtoon.domain.comic.model.RealtimeComicRanking;
+
+public interface RealtimeComicRankingRepository extends JpaRepository<RealtimeComicRanking, Long> {
+}

--- a/src/main/java/com/kongtoon/domain/comic/service/ComicReadService.java
+++ b/src/main/java/com/kongtoon/domain/comic/service/ComicReadService.java
@@ -1,5 +1,7 @@
 package com.kongtoon.domain.comic.service;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -10,6 +12,7 @@ import com.kongtoon.domain.comic.model.dto.response.ComicByGenreResponse;
 import com.kongtoon.domain.comic.model.dto.response.ComicByNewResponse;
 import com.kongtoon.domain.comic.model.dto.response.ComicByRealtimeRankingResponse;
 import com.kongtoon.domain.comic.model.dto.response.ComicByViewRecentResponse;
+import com.kongtoon.domain.comic.model.dto.response.vo.TwoHourSlice;
 import com.kongtoon.domain.comic.repository.ComicRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -40,7 +43,11 @@ public class ComicReadService {
 
 	@Transactional(readOnly = true)
 	public List<ComicByRealtimeRankingResponse> getComicsByRealtimeRanking() {
+		LocalTime now = LocalTime.now();
 
-		return comicRepository.findComicsByRealtimeRanking();
+		TwoHourSlice recordTime = TwoHourSlice.getPrev(now);
+		LocalDate recordDate = recordTime.getPrevSliceDate();
+
+		return comicRepository.findComicsByRealtimeRanking(recordDate, recordTime);
 	}
 }


### PR DESCRIPTION
closed #60 

- 매 조회 시 조회수를 계산하는 로직에서 단순히 테이블에서 조회하도록 코드 변경
- 이 과정에서 스케줄러를 사용하여 매일 오전 1시 59분부터 오후 11시 59분까지 2시간 간격으로 조회수 테이블에서 2시간 동안의 웹툰 별 조회수를 계산하여 1위부터 10위까지의 데이터를 실시간 인기 웹툰 테이블에 삽입하도록 함
- view 테이블이 500만개의 데이터를 가지고 있을 때 5초 -> 실시간 인기 웹툰 테이블의 10년치 데이터인 45만개의 데이터를 가지고 있을 때 0.00초로 성능 개선