### PR TITLE
#65: 테스트 용 DB 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,13 +9,6 @@ group = 'com'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
 
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
-    querydsl.extendsFrom compileClasspath
-}
-
 repositories {
     mavenCentral()
 }
@@ -38,6 +31,9 @@ dependencies {
     // querydsl
     implementation "com.querydsl:querydsl-jpa:5.0.0"
     implementation "com.querydsl:querydsl-apt:5.0.0"
+
+    // H2
+    testImplementation 'com.h2database:h2:2.1.214'
 }
 
 tasks.named('test') {
@@ -60,4 +56,5 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    querydsl.extendsFrom compileClasspath
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,19 @@
+spring:
+  config:
+    activate:
+      on-profile: test
+  h2:
+    console:
+      enabled: true
+  jpa:
+    database: h2
+    generate-ddl: off
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=MySQL;
+    username: SA
+    password:
+  sql:
+    init:
+      mode: always
+      schema-locations: ../../test/resources/test-init.sql

--- a/src/test/resources/test-init.sql
+++ b/src/test/resources/test-init.sql
@@ -1,0 +1,201 @@
+CREATE TABLE users
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    login_id   VARCHAR(15)  NOT NULL,
+    name       VARCHAR(20)  NOT NULL,
+    email      VARCHAR(320) NOT NULL,
+    nickname   VARCHAR(15)  NOT NULL,
+    password   VARCHAR(255) NOT NULL,
+    authority  VARCHAR(20)  NOT NULL,
+    set_alarm  BOOLEAN      NOT NULL,
+    created_at TIMESTAMP    NOT NULL,
+    updated_at TIMESTAMP    NOT NULL,
+    deleted_at TIMESTAMP    NULL,
+    CONSTRAINT users_email_uindex UNIQUE (email),
+    CONSTRAINT users_login_id_uindex UNIQUE (login_id)
+);
+
+CREATE TABLE author
+(
+    id           BIGINT AUTO_INCREMENT PRIMARY KEY,
+    author_name  VARCHAR(20)  NOT NULL,
+    introduction VARCHAR(500) NOT NULL,
+    belong       VARCHAR(15)  NULL,
+    created_at   TIMESTAMP    NOT NULL,
+    updated_at   TIMESTAMP    NOT NULL,
+    deleted_at   TIMESTAMP    NULL,
+    user_id      BIGINT       NOT NULL,
+    CONSTRAINT FK_user_TO_author_1 FOREIGN KEY (user_id) REFERENCES users (id)
+);
+
+CREATE TABLE comic
+(
+    id                  BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name                VARCHAR(30)  NOT NULL,
+    genre               VARCHAR(20)  NOT NULL,
+    summary             VARCHAR(500) NOT NULL,
+    publish_day_of_week VARCHAR(3)   NOT NULL,
+    created_at          TIMESTAMP    NOT NULL,
+    updated_at          TIMESTAMP    NOT NULL,
+    deleted_at          TIMESTAMP    NULL,
+    author_id           BIGINT       NOT NULL,
+    is_complete         BOOLEAN      NOT NULL,
+    CONSTRAINT FK_author_TO_comic_1 FOREIGN KEY (author_id) REFERENCES author (id)
+);
+
+CREATE TABLE alarm
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    is_check   BOOLEAN   NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    deleted_at TIMESTAMP NULL,
+    user_id    BIGINT    NOT NULL,
+    comic_id   BIGINT    NOT NULL,
+    CONSTRAINT FK_comic_TO_alarm_1 FOREIGN KEY (comic_id) REFERENCES comic (id),
+    CONSTRAINT FK_users_TO_alarm_1 FOREIGN KEY (user_id) REFERENCES users (id)
+);
+
+CREATE INDEX id_and_created_at ON comic (id, created_at);
+
+CREATE TABLE episode
+(
+    id             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    title          VARCHAR(255)  NOT NULL,
+    episode_number INT           NOT NULL,
+    thumbnail_url  VARCHAR(2048) NOT NULL,
+    comic_id       BIGINT        NOT NULL,
+    created_at     TIMESTAMP     NOT NULL,
+    updated_at     TIMESTAMP     NOT NULL,
+    deleted_at     TIMESTAMP     NULL,
+    CONSTRAINT FK_comic_TO_episode_1 FOREIGN KEY (comic_id) REFERENCES comic (id)
+);
+
+CREATE TABLE comment
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    content    VARCHAR(500) NOT NULL,
+    parent_id  BIGINT       NULL,
+    visible    BOOLEAN      NOT NULL,
+    created_at TIMESTAMP    NOT NULL,
+    updated_at TIMESTAMP    NOT NULL,
+    deleted_at TIMESTAMP    NULL,
+    user_id    BIGINT       NOT NULL,
+    episode_id BIGINT       NOT NULL,
+    CONSTRAINT FK_episode_TO_comment_1 FOREIGN KEY (episode_id) REFERENCES episode (id),
+    CONSTRAINT FK_users_TO_comment_1 FOREIGN KEY (user_id) REFERENCES users (id)
+);
+
+CREATE TABLE comment_hide
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    created_at TIMESTAMP NOT NULL,
+    deleted_at TIMESTAMP NULL,
+    user_id    BIGINT    NOT NULL,
+    comment_id BIGINT    NOT NULL,
+    CONSTRAINT FK_comment_TO_comment_hide_1 FOREIGN KEY (comment_id) REFERENCES comment (id),
+    CONSTRAINT FK_users_TO_comment_hide_1 FOREIGN KEY (user_id) REFERENCES users (id)
+);
+
+CREATE TABLE comment_report
+(
+    id            BIGINT AUTO_INCREMENT PRIMARY KEY,
+    report_reason VARCHAR(50) NULL,
+    created_at    TIMESTAMP   NOT NULL,
+    deleted_at    TIMESTAMP   NULL,
+    user_id       BIGINT      NOT NULL,
+    comment_id    BIGINT      NOT NULL,
+    CONSTRAINT FK_comment_TO_comment_report_1 FOREIGN KEY (comment_id) REFERENCES comment (id),
+    CONSTRAINT FK_users_TO_comment_report_1 FOREIGN KEY (user_id) REFERENCES users (id)
+);
+
+CREATE INDEX comic_id_AND_episode_number_index ON episode (comic_id, episode_number);
+
+CREATE INDEX comic_id_index_by_episode ON episode (comic_id);
+
+CREATE TABLE episode_image
+(
+    id                BIGINT AUTO_INCREMENT PRIMARY KEY,
+    content_image_url VARCHAR(2048) NOT NULL,
+    content_order     INT DEFAULT 0 NOT NULL,
+    episode_id        BIGINT        NULL,
+    created_at        TIMESTAMP     NOT NULL,
+    updated_at        TIMESTAMP     NOT NULL,
+    deleted_at        TIMESTAMP     NULL,
+    CONSTRAINT episode_image_episode__fk FOREIGN KEY (episode_id) REFERENCES episode (id)
+);
+
+CREATE TABLE follow
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    created_at TIMESTAMP NOT NULL,
+    user_id    BIGINT    NOT NULL,
+    comic_id   BIGINT    NOT NULL,
+    CONSTRAINT FK_comic_TO_follow_1 FOREIGN KEY (comic_id) REFERENCES comic (id),
+    CONSTRAINT FK_users_TO_follow_1 FOREIGN KEY (user_id) REFERENCES users (id)
+);
+
+CREATE TABLE likes
+(
+    id           BIGINT AUTO_INCREMENT PRIMARY KEY,
+    like_type    VARCHAR(15) NOT NULL,
+    reference_id BIGINT      NOT NULL,
+    user_id      BIGINT      NOT NULL,
+    created_at   TIMESTAMP   NOT NULL,
+    CONSTRAINT FK_users_TO_likes_1 FOREIGN KEY (user_id) REFERENCES users (id)
+);
+
+CREATE TABLE realtime_comic_ranking
+(
+    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    record_time VARCHAR(10) NOT NULL,
+    ranks       INT         NOT NULL,
+    views       INT         NOT NULL,
+    comic_id    BIGINT      NOT NULL,
+    created_at  TIMESTAMP   NOT NULL,
+    updated_at  TIMESTAMP   NOT NULL,
+    record_date DATE        NOT NULL,
+    CONSTRAINT FK_realtime_rank_TO_comic FOREIGN KEY (comic_id) REFERENCES comic (id)
+);
+
+CREATE TABLE star
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    score      INT       NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    user_id    BIGINT    NOT NULL,
+    episode_id BIGINT    NOT NULL,
+    CONSTRAINT FK_episode_TO_star_1 FOREIGN KEY (episode_id) REFERENCES episode (id),
+    CONSTRAINT FK_users_TO_star_1 FOREIGN KEY (user_id) REFERENCES users (id)
+);
+
+CREATE TABLE thumbnail
+(
+    id             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    thumbnail_type VARCHAR(10)  NOT NULL,
+    image_url      VARCHAR(255) NOT NULL,
+    comic_id       BIGINT       NOT NULL,
+    created_at     TIMESTAMP    NOT NULL,
+    updated_at     TIMESTAMP    NOT NULL,
+    deleted_at     TIMESTAMP    NULL,
+    CONSTRAINT FK_comic_TO_comic_thumbnail_1 FOREIGN KEY (comic_id) REFERENCES comic (id)
+);
+
+CREATE INDEX comic_id_AND_thumbnail_type ON thumbnail (comic_id, thumbnail_type);
+
+CREATE INDEX comic_id_index_by_thumbnail ON thumbnail (comic_id);
+
+CREATE TABLE view
+(
+    id                BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id           BIGINT    NOT NULL,
+    episode_id        BIGINT    NOT NULL,
+    first_access_time TIMESTAMP NOT NULL,
+    last_access_time  TIMESTAMP NOT NULL,
+    CONSTRAINT FK_episode_TO_view_1 FOREIGN KEY (episode_id) REFERENCES episode (id),
+    CONSTRAINT FK_users_TO_view_1 FOREIGN KEY (user_id) REFERENCES users (id)
+);
+
+CREATE INDEX last_access_time ON view (last_access_time);
+
+CREATE INDEX last_access_time_index ON view (last_access_time);


### PR DESCRIPTION
closed #65 

- 테스트 용 DB는 H2를 사용
  - 인메모리 DB 이기 때문에 속도가 빠름
- 테스트 실행 시 test/resources/test-init.sql 이 실행되면서 테이블이 생성된다.