### PR TITLE
#69: 이메일 검증 로직 수정

### DIFF
--- a/src/main/java/com/kongtoon/common/constant/RegexConst.java
+++ b/src/main/java/com/kongtoon/common/constant/RegexConst.java
@@ -7,4 +7,5 @@ import lombok.NoArgsConstructor;
 public class RegexConst {
 
 	public static final String PASSWORD_VALID_REGEX = "((?=.*\\d)(?=.*[a-z])(?=.*[\\W]).{8,30})";
+	public static final String EMAIL_VALID_REGEX = "[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?";
 }

--- a/src/main/java/com/kongtoon/common/validation/Email.java
+++ b/src/main/java/com/kongtoon/common/validation/Email.java
@@ -1,0 +1,20 @@
+package com.kongtoon.common.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Constraint(validatedBy = EmailFormatValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Email {
+	String message() default "잘못된 형식의 이메일입니다.";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/kongtoon/common/validation/EmailFormatValidator.java
+++ b/src/main/java/com/kongtoon/common/validation/EmailFormatValidator.java
@@ -1,0 +1,19 @@
+package com.kongtoon.common.validation;
+
+import java.util.regex.Pattern;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import org.springframework.stereotype.Component;
+
+import com.kongtoon.common.constant.RegexConst;
+
+@Component
+public class EmailFormatValidator implements ConstraintValidator<Email, String> {
+
+	@Override
+	public boolean isValid(String value, ConstraintValidatorContext context) {
+		return Pattern.matches(RegexConst.EMAIL_VALID_REGEX, value);
+	}
+}

--- a/src/main/java/com/kongtoon/domain/user/dto/request/SignupRequest.java
+++ b/src/main/java/com/kongtoon/domain/user/dto/request/SignupRequest.java
@@ -1,12 +1,12 @@
 package com.kongtoon.domain.user.dto.request;
 
-import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 
 import org.hibernate.validator.constraints.Length;
 
 import com.kongtoon.common.constant.RegexConst;
+import com.kongtoon.common.validation.Email;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.model.UserAuthority;
 
@@ -18,8 +18,8 @@ public record SignupRequest(
 		@NotBlank
 		String name,
 
-		@NotBlank
 		@Email
+		@NotBlank
 		String email,
 
 		@NotBlank


### PR DESCRIPTION
closed #69 

- 이메일 확장자가 없는 경우 검증 로직이 통과하여 정규식을 활용한 새로운 검증 어노테이션을 생성하였다.