### PR TITLE
#100: 여러 사용자가 에피소드 조회 시 발생하는 insert 를 모아서 한 번에 bulk insert 하는 기능 추가

### DIFF
--- a/src/main/java/com/kongtoon/domain/view/model/View.java
+++ b/src/main/java/com/kongtoon/domain/view/model/View.java
@@ -1,28 +1,14 @@
 package com.kongtoon.domain.view.model;
 
-import java.time.LocalDateTime;
-
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import com.kongtoon.domain.episode.model.Episode;
 import com.kongtoon.domain.user.model.User;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "view")
@@ -35,11 +21,9 @@ public class View {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@CreatedDate
 	@Column(name = "first_access_time", nullable = false)
 	private LocalDateTime firstAccessTime;
 
-	@LastModifiedDate
 	@Column(name = "last_access_time", nullable = false)
 	private LocalDateTime lastAccessTime;
 
@@ -54,6 +38,8 @@ public class View {
 	public View(User user, Episode episode) {
 		this.user = user;
 		this.episode = episode;
+		this.firstAccessTime = LocalDateTime.now();
+		this.lastAccessTime = LocalDateTime.now();
 	}
 
 	public void updateLastAccessTime() {

--- a/src/main/java/com/kongtoon/domain/view/repository/ViewJdbcRepository.java
+++ b/src/main/java/com/kongtoon/domain/view/repository/ViewJdbcRepository.java
@@ -1,0 +1,55 @@
+package com.kongtoon.domain.view.repository;
+
+import com.kongtoon.domain.view.model.View;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import javax.transaction.Transactional;
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ViewJdbcRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Transactional
+    public void batchInsert(List<View> views) {
+        String sql = "INSERT INTO view (user_id, episode_id, first_access_time, last_access_time) VALUES (?, ?, ?, ?)";
+
+        jdbcTemplate.batchUpdate(
+                sql,
+                views,
+                views.size(),
+                (PreparedStatement ps, View view) -> {
+                    ps.setLong(1, view.getUser().getId());
+                    ps.setLong(2, view.getEpisode().getId());
+                    ps.setTimestamp(3, Timestamp.valueOf(view.getFirstAccessTime()));
+                    ps.setTimestamp(4, Timestamp.valueOf(view.getLastAccessTime()));
+                }
+        );
+    }
+
+    @Transactional
+    public void batchUpdate(List<View> viewCandidates) {
+        String sql = "INSERT INTO view (id, user_id, episode_id, first_access_time, last_access_time) " +
+                "VALUES (?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE last_access_time = ?";
+
+        jdbcTemplate.batchUpdate(
+                sql,
+                viewCandidates,
+                viewCandidates.size(),
+                (PreparedStatement ps, View view) -> {
+                    ps.setLong(1, view.getId());
+                    ps.setLong(2, view.getUser().getId());
+                    ps.setLong(3, view.getEpisode().getId());
+                    ps.setTimestamp(4, Timestamp.valueOf(view.getFirstAccessTime()));
+                    ps.setTimestamp(5, Timestamp.valueOf(view.getLastAccessTime()));
+                    ps.setTimestamp(6, Timestamp.valueOf(view.getLastAccessTime()));
+                }
+        );
+    }
+}

--- a/src/main/java/com/kongtoon/domain/view/repository/cache/ViewCache.java
+++ b/src/main/java/com/kongtoon/domain/view/repository/cache/ViewCache.java
@@ -1,0 +1,32 @@
+package com.kongtoon.domain.view.repository.cache;
+
+import com.kongtoon.domain.episode.model.Episode;
+import com.kongtoon.domain.user.model.User;
+import com.kongtoon.domain.view.model.View;
+
+import java.util.List;
+
+public interface ViewCache {
+
+    String INSERT_MAP_MAIN_KEY = "insert";
+    String UPDATE_MAP_MAIN_KEY = "update";
+    String USER_LOGIN_ID_PREFIX = "userId:";
+    String EPISODE_ID_PREFIX = "episodeId:";
+    long LIMIT_SIZE = 5000L;
+
+    default String createKey(String loginId, Long episodeId) {
+        return USER_LOGIN_ID_PREFIX + loginId + EPISODE_ID_PREFIX + episodeId;
+    }
+
+    void save(User user, Episode episode);
+
+    boolean existsKey(String mainKey, String subKey);
+
+    List<View> getValues(String mainKey);
+
+    void clear(String mainKey);
+
+    boolean checkInsert();
+
+    boolean checkUpdate();
+}

--- a/src/main/java/com/kongtoon/domain/view/repository/cache/ViewMapCache.java
+++ b/src/main/java/com/kongtoon/domain/view/repository/cache/ViewMapCache.java
@@ -1,0 +1,88 @@
+package com.kongtoon.domain.view.repository.cache;
+
+import com.kongtoon.domain.episode.model.Episode;
+import com.kongtoon.domain.user.model.User;
+import com.kongtoon.domain.view.model.View;
+import com.kongtoon.domain.view.repository.ViewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+@RequiredArgsConstructor
+public class ViewMapCache implements ViewCache {
+
+    private static final Map<String, Map<String, View>> viewCache = new HashMap<>();
+
+    private final ViewRepository viewRepository;
+
+    @Override
+    public void save(User user, Episode episode) {
+        String subKey = createKey(user.getLoginId(), episode.getId());
+        Map<String, View> viewsForInsert = viewCache.get(INSERT_MAP_MAIN_KEY);
+        Map<String, View> viewsForUpdate = viewCache.get(UPDATE_MAP_MAIN_KEY);
+
+        viewRepository.findByUserAndEpisode(user, episode)
+                .ifPresentOrElse(
+                        view -> saveKeyInUpdateMap(subKey, view, viewsForUpdate),
+                        () -> saveKeyInInsertMap(new View(user, episode), subKey, viewsForInsert)
+                );
+    }
+
+    @Override
+    public boolean existsKey(String mainKey, String subKey) {
+        return viewCache.get(mainKey)
+                .containsKey(subKey);
+    }
+
+    @Override
+    public List<View> getValues(String mainKey) {
+        return viewCache.get(mainKey)
+                .values()
+                .stream()
+                .toList();
+    }
+
+    @Override
+    public void clear(String mainKey) {
+        viewCache.get(mainKey)
+                .clear();
+    }
+
+    @Override
+    public boolean checkInsert() {
+        return viewCache.get(INSERT_MAP_MAIN_KEY)
+                .size() >= LIMIT_SIZE;
+    }
+
+    @Override
+    public boolean checkUpdate() {
+        return viewCache.get(UPDATE_MAP_MAIN_KEY)
+                .size() >= LIMIT_SIZE;
+    }
+
+    private void saveKeyInInsertMap(View view, String subKey, Map<String, View> viewsForInsert) {
+        if (existsKey(INSERT_MAP_MAIN_KEY, subKey)) {
+            View findView = viewsForInsert.get(subKey);
+            findView.updateLastAccessTime();
+        } else {
+            viewsForInsert.put(subKey, view);
+        }
+    }
+
+    private void saveKeyInUpdateMap(String subKey, View view, Map<String, View> viewsForUpdate) {
+        view.updateLastAccessTime();
+        viewsForUpdate.put(subKey, view);
+    }
+
+    @PostConstruct
+    private void init() {
+        viewCache.put(INSERT_MAP_MAIN_KEY, new ConcurrentHashMap<>());
+        viewCache.put(UPDATE_MAP_MAIN_KEY, new ConcurrentHashMap<>());
+    }
+}

--- a/src/main/java/com/kongtoon/domain/view/service/event/EpisodeViewedEvent.java
+++ b/src/main/java/com/kongtoon/domain/view/service/event/EpisodeViewedEvent.java
@@ -3,7 +3,6 @@ package com.kongtoon.domain.view.service.event;
 import com.kongtoon.domain.episode.model.Episode;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.view.model.View;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -11,9 +10,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public class EpisodeViewedEvent {
 
-	User user;
-
-	Episode episode;
+	private final User user;
+	private final Episode episode;
 
 	public View toView() {
 		return new View(


### PR DESCRIPTION
- insert 쿼리 수를 줄이기 위함
- 추후 인메모리가 아닌 글로벌 캐시를 적용할 수 있기 때문에 `ViewCache` 인터페이스를 구현하도록 함
- JPA + IDENTITY Id 생성 전략의 경우 JPA 에서 제공하는 bulk insert 가 동작하지 않음. 따라서 JDBC template 사용