### PR TITLE
#108: 이메일, 패스워드, 로그인 ID를 객체로 관리하도록 변경

### DIFF
--- a/src/main/java/com/kongtoon/common/validation/EmailFormatValidator.java
+++ b/src/main/java/com/kongtoon/common/validation/EmailFormatValidator.java
@@ -1,6 +1,7 @@
 package com.kongtoon.common.validation;
 
 import com.kongtoon.common.constant.RegexConst;
+import com.kongtoon.domain.user.model.Email;
 import org.springframework.stereotype.Component;
 
 import javax.validation.ConstraintValidator;
@@ -8,10 +9,10 @@ import javax.validation.ConstraintValidatorContext;
 import java.util.regex.Pattern;
 
 @Component
-public class EmailFormatValidator implements ConstraintValidator<EmailValid, String> {
+public class EmailFormatValidator implements ConstraintValidator<EmailValid, Email> {
 
 	@Override
-	public boolean isValid(String value, ConstraintValidatorContext context) {
-		return Pattern.matches(RegexConst.EMAIL_VALID_REGEX, value);
+	public boolean isValid(Email email, ConstraintValidatorContext context) {
+		return Pattern.matches(RegexConst.EMAIL_VALID_REGEX, email.getAddress());
 	}
 }

--- a/src/main/java/com/kongtoon/common/validation/EmailFormatValidator.java
+++ b/src/main/java/com/kongtoon/common/validation/EmailFormatValidator.java
@@ -11,8 +11,27 @@ import java.util.regex.Pattern;
 @Component
 public class EmailFormatValidator implements ConstraintValidator<EmailValid, Email> {
 
+	private static final String INVALID_EMAIL_ADDRESS_MESSAGE = "잘못된 형식의 이메일입니다.";
+	private static final String ADDRESS_FIELD = "address";
+
 	@Override
 	public boolean isValid(Email email, ConstraintValidatorContext context) {
-		return Pattern.matches(RegexConst.EMAIL_VALID_REGEX, email.getAddress());
+		if (validateEmailAddress(email)) {
+			addConstraintViolation(context, INVALID_EMAIL_ADDRESS_MESSAGE, ADDRESS_FIELD);
+			return false;
+		}
+
+		return true;
+	}
+
+	private static boolean validateEmailAddress(Email email) {
+		return !Pattern.matches(RegexConst.EMAIL_VALID_REGEX, email.getAddress());
+	}
+
+	private void addConstraintViolation(ConstraintValidatorContext context, String errorMessage, String firstNode) {
+		context.disableDefaultConstraintViolation();
+		context.buildConstraintViolationWithTemplate(errorMessage)
+				.addPropertyNode(firstNode)
+				.addConstraintViolation();
 	}
 }

--- a/src/main/java/com/kongtoon/common/validation/EmailFormatValidator.java
+++ b/src/main/java/com/kongtoon/common/validation/EmailFormatValidator.java
@@ -1,16 +1,14 @@
 package com.kongtoon.common.validation;
 
-import java.util.regex.Pattern;
+import com.kongtoon.common.constant.RegexConst;
+import org.springframework.stereotype.Component;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
-
-import org.springframework.stereotype.Component;
-
-import com.kongtoon.common.constant.RegexConst;
+import java.util.regex.Pattern;
 
 @Component
-public class EmailFormatValidator implements ConstraintValidator<Email, String> {
+public class EmailFormatValidator implements ConstraintValidator<EmailValid, String> {
 
 	@Override
 	public boolean isValid(String value, ConstraintValidatorContext context) {

--- a/src/main/java/com/kongtoon/common/validation/EmailValid.java
+++ b/src/main/java/com/kongtoon/common/validation/EmailValid.java
@@ -8,9 +8,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Constraint(validatedBy = EmailFormatValidator.class)
-@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Email {
+public @interface EmailValid {
 	String message() default "잘못된 형식의 이메일입니다.";
 
 	Class<?>[] groups() default {};

--- a/src/main/java/com/kongtoon/domain/author/service/AuthorService.java
+++ b/src/main/java/com/kongtoon/domain/author/service/AuthorService.java
@@ -1,12 +1,5 @@
 package com.kongtoon.domain.author.service;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.kongtoon.common.exception.BusinessException;
 import com.kongtoon.common.exception.ErrorCode;
 import com.kongtoon.domain.author.model.Author;
@@ -20,11 +13,17 @@ import com.kongtoon.domain.comic.repository.ComicRepository;
 import com.kongtoon.domain.comic.repository.ThumbnailRepository;
 import com.kongtoon.domain.episode.model.Episode;
 import com.kongtoon.domain.episode.repository.EpisodeRepository;
+import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.model.UserAuthority;
 import com.kongtoon.domain.user.repository.UserRepository;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -40,7 +39,7 @@ public class AuthorService {
 	private final EpisodeRepository episodeRepository;
 
 	@Transactional
-	public Long createAuthor(AuthorCreateRequest authorCreateRequest, String loginId) {
+	public Long createAuthor(AuthorCreateRequest authorCreateRequest, LoginId loginId) {
 		User user = userRepository.findByLoginId(loginId)
 				.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 

--- a/src/main/java/com/kongtoon/domain/comic/service/ComicModifyService.java
+++ b/src/main/java/com/kongtoon/domain/comic/service/ComicModifyService.java
@@ -1,12 +1,5 @@
 package com.kongtoon.domain.comic.service;
 
-import java.util.List;
-
-import javax.transaction.Transactional;
-
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Service;
-
 import com.kongtoon.common.aws.FileStorage;
 import com.kongtoon.common.aws.ImageFileType;
 import com.kongtoon.common.aws.event.FileDeleteAfterCommitEvent;
@@ -21,10 +14,15 @@ import com.kongtoon.domain.comic.model.dto.request.ComicRequest;
 import com.kongtoon.domain.comic.model.dto.request.ComicRequest.ThumbnailRequest;
 import com.kongtoon.domain.comic.repository.ComicRepository;
 import com.kongtoon.domain.comic.repository.ThumbnailRepository;
+import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.repository.UserRepository;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -40,7 +38,7 @@ public class ComicModifyService {
 	private final ApplicationEventPublisher applicationEventPublisher;
 
 	@Transactional
-	public Long createComic(ComicRequest comicRequest, String loginId) {
+	public Long createComic(ComicRequest comicRequest, LoginId loginId) {
 		User user = getUser(loginId);
 		Author author = getAuthor(user);
 
@@ -64,7 +62,7 @@ public class ComicModifyService {
 	}
 
 	@Transactional
-	public void updateComic(ComicRequest comicRequest, Long comicId, String loginId) {
+	public void updateComic(ComicRequest comicRequest, Long comicId, LoginId loginId) {
 		User user = getUser(loginId);
 		Comic comic = getComicWithAuthor(comicId);
 		Author author = comic.getAuthor();
@@ -115,7 +113,7 @@ public class ComicModifyService {
 				.orElseThrow(() -> new BusinessException(ErrorCode.AUTHOR_NOT_FOUND));
 	}
 
-	private User getUser(String loginId) {
+	private User getUser(LoginId loginId) {
 		return userRepository.findByLoginId(loginId)
 				.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 	}

--- a/src/main/java/com/kongtoon/domain/episode/service/EpisodeModifyService.java
+++ b/src/main/java/com/kongtoon/domain/episode/service/EpisodeModifyService.java
@@ -1,12 +1,5 @@
 package com.kongtoon.domain.episode.service;
 
-import java.util.List;
-
-import javax.transaction.Transactional;
-
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Service;
-
 import com.kongtoon.common.aws.FileStorage;
 import com.kongtoon.common.aws.FileType;
 import com.kongtoon.common.aws.ImageFileType;
@@ -22,10 +15,15 @@ import com.kongtoon.domain.episode.model.dto.request.EpisodeRequest;
 import com.kongtoon.domain.episode.model.dto.request.EpisodeRequest.EpisodeContentRequest;
 import com.kongtoon.domain.episode.repository.EpisodeImageRepository;
 import com.kongtoon.domain.episode.repository.EpisodeRepository;
+import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.repository.UserRepository;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -42,7 +40,7 @@ public class EpisodeModifyService {
 	private final ApplicationEventPublisher applicationEventPublisher;
 
 	@Transactional
-	public Long createEpisodeAndEpisodeImage(EpisodeRequest episodeRequest, Long comicId, String loginId) {
+	public Long createEpisodeAndEpisodeImage(EpisodeRequest episodeRequest, Long comicId, LoginId loginId) {
 		User user = getUser(loginId);
 		Comic comic = getComicWithAuthor(comicId);
 
@@ -81,7 +79,7 @@ public class EpisodeModifyService {
 	}
 
 	@Transactional
-	public void updateEpisode(EpisodeRequest episodeRequest, Long episodeId, String loginId) {
+	public void updateEpisode(EpisodeRequest episodeRequest, Long episodeId, LoginId loginId) {
 		User user = getUser(loginId);
 		Episode episode = getEpisodeWithComicAndAuthor(episodeId);
 		Comic comic = episode.getComic();
@@ -218,7 +216,7 @@ public class EpisodeModifyService {
 		}
 	}
 
-	private User getUser(String loginId) {
+	private User getUser(LoginId loginId) {
 		return userRepository.findByLoginId(loginId)
 				.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 	}

--- a/src/main/java/com/kongtoon/domain/episode/service/EpisodeReadService.java
+++ b/src/main/java/com/kongtoon/domain/episode/service/EpisodeReadService.java
@@ -1,14 +1,5 @@
 package com.kongtoon.domain.episode.service;
 
-import static com.kongtoon.domain.episode.model.dto.response.EpisodeDetailResponse.*;
-import static com.kongtoon.domain.episode.model.dto.response.EpisodeResponse.*;
-
-import java.util.List;
-
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.kongtoon.common.exception.BusinessException;
 import com.kongtoon.common.exception.ErrorCode;
 import com.kongtoon.domain.comic.model.Comic;
@@ -30,13 +21,21 @@ import com.kongtoon.domain.follow.repository.FollowRepository;
 import com.kongtoon.domain.like.model.LikeType;
 import com.kongtoon.domain.like.repository.LikeRepository;
 import com.kongtoon.domain.star.repository.StarRepository;
+import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.repository.UserRepository;
 import com.kongtoon.domain.view.model.View;
 import com.kongtoon.domain.view.repository.ViewRepository;
 import com.kongtoon.domain.view.service.event.EpisodeViewedEvent;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.kongtoon.domain.episode.model.dto.response.EpisodeDetailResponse.*;
+import static com.kongtoon.domain.episode.model.dto.response.EpisodeResponse.EpisodeImageResponse;
 
 @Service
 @RequiredArgsConstructor
@@ -59,7 +58,7 @@ public class EpisodeReadService {
 	private final ApplicationEventPublisher applicationEventPublisher;
 
 	@Transactional(readOnly = true)
-	public EpisodeListResponses getEpisodes(Long comicId, String loginId) {
+	public EpisodeListResponses getEpisodes(Long comicId, LoginId loginId) {
 		List<Episode> episodes = episodeRepository.findByComicIdWithComicAndAuthor(comicId);
 		Comic comic = getComic(comicId);
 		User user = getUser(loginId);
@@ -85,7 +84,7 @@ public class EpisodeReadService {
 	}
 
 	@Transactional(readOnly = true)
-	public EpisodeDetailResponse getEpisodeDetailResponse(Long episodeId, String loginId) {
+	public EpisodeDetailResponse getEpisodeDetailResponse(Long episodeId, LoginId loginId) {
 		User user = getUser(loginId);
 		Episode episode = getEpisodeWithComic(episodeId);
 		Comic comic = episode.getComic();
@@ -141,7 +140,7 @@ public class EpisodeReadService {
 				.orElseThrow(() -> new BusinessException(ErrorCode.COMIC_NOT_FOUND));
 	}
 
-	private User getUser(String loginId) {
+	private User getUser(LoginId loginId) {
 		return userRepository.findByLoginId(loginId)
 				.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 	}

--- a/src/main/java/com/kongtoon/domain/follow/service/FollowService.java
+++ b/src/main/java/com/kongtoon/domain/follow/service/FollowService.java
@@ -1,10 +1,5 @@
 package com.kongtoon.domain.follow.service;
 
-import java.util.Optional;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.kongtoon.common.exception.BusinessException;
 import com.kongtoon.common.exception.ErrorCode;
 import com.kongtoon.domain.comic.model.Comic;
@@ -12,10 +7,14 @@ import com.kongtoon.domain.comic.repository.ComicRepository;
 import com.kongtoon.domain.follow.model.Follow;
 import com.kongtoon.domain.follow.model.dto.response.FollowResponse;
 import com.kongtoon.domain.follow.repository.FollowRepository;
+import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.repository.UserRepository;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -26,7 +25,7 @@ public class FollowService {
 	private final UserRepository userRepository;
 
 	@Transactional
-	public FollowResponse createFollow(Long comicId, String loginId) {
+	public FollowResponse createFollow(Long comicId, LoginId loginId) {
 		User user = getUser(loginId);
 		Comic comic = getComic(comicId);
 
@@ -46,7 +45,7 @@ public class FollowService {
 	}
 
 	@Transactional
-	public FollowResponse deleteFollow(Long comicId, String loginId) {
+	public FollowResponse deleteFollow(Long comicId, LoginId loginId) {
 		User user = getUser(loginId);
 		Comic comic = getComic(comicId);
 
@@ -67,7 +66,7 @@ public class FollowService {
 		return new Follow(user, comic);
 	}
 
-	private User getUser(String loginId) {
+	private User getUser(LoginId loginId) {
 		return userRepository.findByLoginId(loginId)
 				.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 	}

--- a/src/main/java/com/kongtoon/domain/like/service/LikeService.java
+++ b/src/main/java/com/kongtoon/domain/like/service/LikeService.java
@@ -1,8 +1,5 @@
 package com.kongtoon.domain.like.service;
 
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.kongtoon.common.exception.BusinessException;
 import com.kongtoon.common.exception.ErrorCode;
 import com.kongtoon.domain.episode.repository.EpisodeRepository;
@@ -10,10 +7,12 @@ import com.kongtoon.domain.like.model.Like;
 import com.kongtoon.domain.like.model.LikeType;
 import com.kongtoon.domain.like.model.dto.response.LikeResponse;
 import com.kongtoon.domain.like.repository.LikeRepository;
+import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.repository.UserRepository;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,7 +23,7 @@ public class LikeService {
 	private final EpisodeRepository episodeRepository;
 
 	@Transactional
-	public LikeResponse createEpisodeLike(Long episodeId, String loginId) {
+	public LikeResponse createEpisodeLike(Long episodeId, LoginId loginId) {
 		User user = getUser(loginId);
 
 		verityExistsEpisode(episodeId);
@@ -39,7 +38,7 @@ public class LikeService {
 	}
 
 	@Transactional
-	public LikeResponse deleteEpisodeLike(Long episodeId, String loginId) {
+	public LikeResponse deleteEpisodeLike(Long episodeId, LoginId loginId) {
 		User user = getUser(loginId);
 
 		likeRepository.findByUserAndLikeTypeAndReferenceId(user, LikeType.EPISODE, episodeId)
@@ -66,7 +65,7 @@ public class LikeService {
 		}
 	}
 
-	private User getUser(String loginId) {
+	private User getUser(LoginId loginId) {
 		return userRepository.findByLoginId(loginId)
 				.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 	}

--- a/src/main/java/com/kongtoon/domain/star/service/StarService.java
+++ b/src/main/java/com/kongtoon/domain/star/service/StarService.java
@@ -1,20 +1,19 @@
 package com.kongtoon.domain.star.service;
 
-import java.util.Optional;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.kongtoon.common.exception.BusinessException;
 import com.kongtoon.common.exception.ErrorCode;
 import com.kongtoon.domain.episode.model.Episode;
 import com.kongtoon.domain.episode.repository.EpisodeRepository;
 import com.kongtoon.domain.star.model.Star;
 import com.kongtoon.domain.star.repository.StarRepository;
+import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.repository.UserRepository;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -25,7 +24,7 @@ public class StarService {
 	private final EpisodeRepository episodeRepository;
 
 	@Transactional
-	public Long createStar(Long episodeId, String loginId, int score) {
+	public Long createStar(Long episodeId, LoginId loginId, int score) {
 		User user = getUser(loginId);
 		Episode episode = getEpisode(episodeId);
 
@@ -46,7 +45,7 @@ public class StarService {
 		return starRepository.findByUserAndEpisode(user, episode);
 	}
 
-	private User getUser(String loginId) {
+	private User getUser(LoginId loginId) {
 		return userRepository.findByLoginId(loginId)
 				.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 	}

--- a/src/main/java/com/kongtoon/domain/user/controller/UserController.java
+++ b/src/main/java/com/kongtoon/domain/user/controller/UserController.java
@@ -5,9 +5,9 @@ import com.kongtoon.common.validation.Email;
 import com.kongtoon.domain.user.dto.UserAuthDTO;
 import com.kongtoon.domain.user.dto.request.LoginRequest;
 import com.kongtoon.domain.user.dto.request.SignupRequest;
+import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.validator.constraints.Length;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -60,7 +60,7 @@ public class UserController {
 
 	@PostMapping("/signup/check-duplicate-id/{loginId}")
 	public ResponseEntity<Void> checkDuplicateId(
-			@PathVariable @NotBlank @Length(min = 5, max = 20) String loginId
+			@PathVariable @Valid LoginId loginId
 	) {
 		userService.validateDuplicateLoginId(loginId);
 

--- a/src/main/java/com/kongtoon/domain/user/controller/UserController.java
+++ b/src/main/java/com/kongtoon/domain/user/controller/UserController.java
@@ -1,10 +1,10 @@
 package com.kongtoon.domain.user.controller;
 
 import com.kongtoon.common.session.UserSessionUtil;
-import com.kongtoon.common.validation.Email;
 import com.kongtoon.domain.user.dto.UserAuthDTO;
 import com.kongtoon.domain.user.dto.request.LoginRequest;
 import com.kongtoon.domain.user.dto.request.SignupRequest;
+import com.kongtoon.domain.user.model.Email;
 import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
 import java.net.URI;
 
 @RestController
@@ -69,7 +68,7 @@ public class UserController {
 
 	@PostMapping("/signup/check-duplicate-email/{email}")
 	public ResponseEntity<Void> checkDuplicateEmail(
-			@PathVariable @NotBlank @Email String email
+			@PathVariable @Valid Email email
 	) {
 		userService.validateDuplicateEmail(email);
 

--- a/src/main/java/com/kongtoon/domain/user/dto/UserAuthDTO.java
+++ b/src/main/java/com/kongtoon/domain/user/dto/UserAuthDTO.java
@@ -1,9 +1,10 @@
 package com.kongtoon.domain.user.dto;
 
+import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.model.UserAuthority;
 
-public record UserAuthDTO(Long userId, String loginId, UserAuthority userAuthority) {
+public record UserAuthDTO(Long userId, LoginId loginId, UserAuthority userAuthority) {
 	public static UserAuthDTO from(User user) {
 		return new UserAuthDTO(user.getId(), user.getLoginId(), user.getAuthority());
 	}

--- a/src/main/java/com/kongtoon/domain/user/dto/request/LoginRequest.java
+++ b/src/main/java/com/kongtoon/domain/user/dto/request/LoginRequest.java
@@ -1,10 +1,14 @@
 package com.kongtoon.domain.user.dto.request;
 
+import com.kongtoon.domain.user.model.LoginId;
+
+import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 
 public record LoginRequest(
-		@NotBlank
-		String loginId,
+		@Valid
+		LoginId loginId,
+
 		@NotBlank
 		String password) {
 }

--- a/src/main/java/com/kongtoon/domain/user/dto/request/LoginRequest.java
+++ b/src/main/java/com/kongtoon/domain/user/dto/request/LoginRequest.java
@@ -1,14 +1,15 @@
 package com.kongtoon.domain.user.dto.request;
 
 import com.kongtoon.domain.user.model.LoginId;
+import com.kongtoon.domain.user.model.Password;
 
 import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
 
 public record LoginRequest(
 		@Valid
 		LoginId loginId,
 
-		@NotBlank
-		String password) {
+		@Valid
+		Password password
+) {
 }

--- a/src/main/java/com/kongtoon/domain/user/dto/request/SignupRequest.java
+++ b/src/main/java/com/kongtoon/domain/user/dto/request/SignupRequest.java
@@ -1,15 +1,9 @@
 package com.kongtoon.domain.user.dto.request;
 
-import com.kongtoon.common.constant.RegexConst;
-import com.kongtoon.domain.user.model.Email;
-import com.kongtoon.domain.user.model.LoginId;
-import com.kongtoon.domain.user.model.User;
-import com.kongtoon.domain.user.model.UserAuthority;
-import org.hibernate.validator.constraints.Length;
+import com.kongtoon.domain.user.model.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Pattern;
 
 public record SignupRequest(
 		@Valid
@@ -24,13 +18,11 @@ public record SignupRequest(
 		@NotBlank
 		String nickname,
 
-		@NotBlank
-		@Pattern(regexp = RegexConst.PASSWORD_VALID_REGEX, message = "비밀번호 형식이 일치하지 않습니다.")
-		@Length(min = 8, max = 30)
-		String password
+		@Valid
+		Password password
 ) {
 
-	public User toEntity(String encryptPassword) {
-		return new User(loginId, name, email, nickname, encryptPassword, UserAuthority.USER, true);
+	public User toEntity() {
+		return new User(loginId, name, email, nickname, password, UserAuthority.USER, true);
 	}
 }

--- a/src/main/java/com/kongtoon/domain/user/dto/request/SignupRequest.java
+++ b/src/main/java/com/kongtoon/domain/user/dto/request/SignupRequest.java
@@ -1,7 +1,7 @@
 package com.kongtoon.domain.user.dto.request;
 
 import com.kongtoon.common.constant.RegexConst;
-import com.kongtoon.common.validation.Email;
+import com.kongtoon.domain.user.model.Email;
 import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.model.UserAuthority;
@@ -18,9 +18,8 @@ public record SignupRequest(
 		@NotBlank
 		String name,
 
-		@Email
-		@NotBlank
-		String email,
+		@Valid
+		Email email,
 
 		@NotBlank
 		String nickname,

--- a/src/main/java/com/kongtoon/domain/user/dto/request/SignupRequest.java
+++ b/src/main/java/com/kongtoon/domain/user/dto/request/SignupRequest.java
@@ -1,19 +1,19 @@
 package com.kongtoon.domain.user.dto.request;
 
+import com.kongtoon.common.constant.RegexConst;
+import com.kongtoon.common.validation.Email;
+import com.kongtoon.domain.user.model.LoginId;
+import com.kongtoon.domain.user.model.User;
+import com.kongtoon.domain.user.model.UserAuthority;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 
-import org.hibernate.validator.constraints.Length;
-
-import com.kongtoon.common.constant.RegexConst;
-import com.kongtoon.common.validation.Email;
-import com.kongtoon.domain.user.model.User;
-import com.kongtoon.domain.user.model.UserAuthority;
-
 public record SignupRequest(
-		@NotBlank
-		@Length(min = 5, max = 20)
-		String loginId,
+		@Valid
+		LoginId loginId,
 
 		@NotBlank
 		String name,

--- a/src/main/java/com/kongtoon/domain/user/model/Email.java
+++ b/src/main/java/com/kongtoon/domain/user/model/Email.java
@@ -2,18 +2,18 @@ package com.kongtoon.domain.user.model;
 
 import com.kongtoon.common.validation.EmailValid;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 import org.hibernate.validator.constraints.Length;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.validation.constraints.NotBlank;
 
-@ToString
 @EmailValid
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
 public class Email {
@@ -22,8 +22,4 @@ public class Email {
     @NotBlank
     @Column(name = "email", unique = true, length = 320, nullable = false)
     private String address;
-
-    public Email(String address) {
-        this.address = address;
-    }
 }

--- a/src/main/java/com/kongtoon/domain/user/model/Email.java
+++ b/src/main/java/com/kongtoon/domain/user/model/Email.java
@@ -1,0 +1,29 @@
+package com.kongtoon.domain.user.model;
+
+import com.kongtoon.common.validation.EmailValid;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.validator.constraints.Length;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.validation.constraints.NotBlank;
+
+@ToString
+@EmailValid
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class Email {
+
+    @Length(max = 320)
+    @NotBlank
+    @Column(name = "email", unique = true, length = 320, nullable = false)
+    private String address;
+
+    public Email(String address) {
+        this.address = address;
+    }
+}

--- a/src/main/java/com/kongtoon/domain/user/model/LoginId.java
+++ b/src/main/java/com/kongtoon/domain/user/model/LoginId.java
@@ -1,0 +1,36 @@
+package com.kongtoon.domain.user.model;
+
+import com.mysema.commons.lang.Assert;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class LoginId {
+
+    private static final int MIN_ID_LENGTH = 5;
+    private static final int MAX_ID_LENGTH = 20;
+    private static final String INVALID_ID_LENGTH_MESSAGE = "로그인 ID 길이 검증에 실패했습니다.";
+
+    @NotBlank
+    @Length(min = MIN_ID_LENGTH, max = MAX_ID_LENGTH)
+    @Column(name = "login_id", unique = true, length = 15, nullable = false)
+    private String idValue;
+
+    public LoginId(String idValue) {
+        Assert.isTrue(validatedLoginIdLength(idValue), INVALID_ID_LENGTH_MESSAGE);
+
+        this.idValue = idValue;
+    }
+
+    private boolean validatedLoginIdLength(String idValue) {
+        return idValue.length() >= MIN_ID_LENGTH && idValue.length() <= MAX_ID_LENGTH;
+    }
+}

--- a/src/main/java/com/kongtoon/domain/user/model/Password.java
+++ b/src/main/java/com/kongtoon/domain/user/model/Password.java
@@ -1,0 +1,33 @@
+package com.kongtoon.domain.user.model;
+
+import com.kongtoon.common.constant.RegexConst;
+import com.kongtoon.common.security.PasswordEncoder;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class Password {
+
+    private static final String INVALID_PASSWORD_MESSAGE = "비밀번호 형식이 일치하지 않습니다.";
+
+    @Pattern(regexp = RegexConst.PASSWORD_VALID_REGEX, message = INVALID_PASSWORD_MESSAGE)
+    @Length(min = 8, max = 30)
+    @NotBlank
+    @Column(name = "password", length = 255, nullable = false)
+    private String passwordValue;
+
+    public void encryptPassword(PasswordEncoder passwordEncoder) {
+        this.passwordValue = passwordEncoder.encrypt(this.passwordValue);
+    }
+}

--- a/src/main/java/com/kongtoon/domain/user/model/User.java
+++ b/src/main/java/com/kongtoon/domain/user/model/User.java
@@ -33,8 +33,8 @@ public class User extends BaseEntity {
 	@Column(name = "nickname", length = 15, nullable = false)
 	private String nickname;
 
-	@Column(name = "password", length = 255, nullable = false)
-	private String password;
+	@Embedded
+	private Password password;
 
 	@Enumerated(value = EnumType.STRING)
 	@Column(name = "authority", length = 20, nullable = false)
@@ -46,7 +46,7 @@ public class User extends BaseEntity {
 	@Column(name = "deleted_at", nullable = true)
 	private LocalDateTime deletedAt;
 
-	public User(LoginId loginId, String name, Email email, String nickname, String password, UserAuthority authority,
+	public User(LoginId loginId, String name, Email email, String nickname, Password password, UserAuthority authority,
 			boolean setAlarm) {
 		this.loginId = loginId;
 		this.name = name;

--- a/src/main/java/com/kongtoon/domain/user/model/User.java
+++ b/src/main/java/com/kongtoon/domain/user/model/User.java
@@ -27,8 +27,8 @@ public class User extends BaseEntity {
 	@Column(name = "name", length = 20, nullable = false)
 	private String name;
 
-	@Column(name = "email", unique = true, length = 320, nullable = false)
-	private String email;
+	@Embedded
+	private Email email;
 
 	@Column(name = "nickname", length = 15, nullable = false)
 	private String nickname;
@@ -46,7 +46,7 @@ public class User extends BaseEntity {
 	@Column(name = "deleted_at", nullable = true)
 	private LocalDateTime deletedAt;
 
-	public User(LoginId loginId, String name, String email, String nickname, String password, UserAuthority authority,
+	public User(LoginId loginId, String name, Email email, String nickname, String password, UserAuthority authority,
 			boolean setAlarm) {
 		this.loginId = loginId;
 		this.name = name;

--- a/src/main/java/com/kongtoon/domain/user/model/User.java
+++ b/src/main/java/com/kongtoon/domain/user/model/User.java
@@ -1,24 +1,14 @@
 package com.kongtoon.domain.user.model;
 
-import java.time.LocalDateTime;
-
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
-
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
-
 import com.kongtoon.domain.BaseEntity;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "users")
@@ -31,8 +21,8 @@ public class User extends BaseEntity {
 	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = "login_id", unique = true, length = 15, nullable = false)
-	private String loginId;
+	@Embedded
+	private LoginId loginId;
 
 	@Column(name = "name", length = 20, nullable = false)
 	private String name;
@@ -56,7 +46,7 @@ public class User extends BaseEntity {
 	@Column(name = "deleted_at", nullable = true)
 	private LocalDateTime deletedAt;
 
-	public User(String loginId, String name, String email, String nickname, String password, UserAuthority authority,
+	public User(LoginId loginId, String name, String email, String nickname, String password, UserAuthority authority,
 			boolean setAlarm) {
 		this.loginId = loginId;
 		this.name = name;

--- a/src/main/java/com/kongtoon/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/kongtoon/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.kongtoon.domain.user.repository;
 
+import com.kongtoon.domain.user.model.Email;
 import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,5 +13,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
 	boolean existsByLoginId(LoginId loginId);
 
-	boolean existsByEmail(String email);
+	boolean existsByEmail(Email email);
 }

--- a/src/main/java/com/kongtoon/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/kongtoon/domain/user/repository/UserRepository.java
@@ -1,16 +1,16 @@
 package com.kongtoon.domain.user.repository;
 
-import java.util.Optional;
-
+import com.kongtoon.domain.user.model.LoginId;
+import com.kongtoon.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.kongtoon.domain.user.model.User;
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-	Optional<User> findByLoginId(String loginId);
+	Optional<User> findByLoginId(LoginId loginId);
 
-	boolean existsByLoginId(String loginId);
+	boolean existsByLoginId(LoginId loginId);
 
 	boolean existsByEmail(String email);
 }

--- a/src/main/java/com/kongtoon/domain/user/service/UserService.java
+++ b/src/main/java/com/kongtoon/domain/user/service/UserService.java
@@ -6,6 +6,7 @@ import com.kongtoon.common.security.PasswordEncoder;
 import com.kongtoon.domain.user.dto.UserAuthDTO;
 import com.kongtoon.domain.user.dto.request.LoginRequest;
 import com.kongtoon.domain.user.dto.request.SignupRequest;
+import com.kongtoon.domain.user.model.Email;
 import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.repository.UserRepository;
@@ -54,7 +55,7 @@ public class UserService {
 		}
 	}
 
-	public void validateDuplicateEmail(String email) {
+	public void validateDuplicateEmail(Email email) {
 		if (userRepository.existsByEmail(email)) {
 			throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
 		}

--- a/src/main/java/com/kongtoon/domain/user/service/UserService.java
+++ b/src/main/java/com/kongtoon/domain/user/service/UserService.java
@@ -1,18 +1,17 @@
 package com.kongtoon.domain.user.service;
 
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.kongtoon.common.exception.BusinessException;
 import com.kongtoon.common.exception.ErrorCode;
 import com.kongtoon.common.security.PasswordEncoder;
 import com.kongtoon.domain.user.dto.UserAuthDTO;
 import com.kongtoon.domain.user.dto.request.LoginRequest;
 import com.kongtoon.domain.user.dto.request.SignupRequest;
+import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.repository.UserRepository;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -49,7 +48,7 @@ public class UserService {
 		return user.getId();
 	}
 
-	public void validateDuplicateLoginId(String loginId) {
+	public void validateDuplicateLoginId(LoginId loginId) {
 		if (userRepository.existsByLoginId(loginId)) {
 			throw new BusinessException(ErrorCode.DUPLICATE_LOGIN_ID);
 		}

--- a/src/main/java/com/kongtoon/domain/user/service/UserService.java
+++ b/src/main/java/com/kongtoon/domain/user/service/UserService.java
@@ -8,6 +8,7 @@ import com.kongtoon.domain.user.dto.request.LoginRequest;
 import com.kongtoon.domain.user.dto.request.SignupRequest;
 import com.kongtoon.domain.user.model.Email;
 import com.kongtoon.domain.user.model.LoginId;
+import com.kongtoon.domain.user.model.Password;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -30,8 +31,8 @@ public class UserService {
 		return UserAuthDTO.from(user);
 	}
 
-	private void validatePasswordIsCorrect(String inputPassword, String originPassword) {
-		if (!passwordEncoder.isMatch(inputPassword, originPassword)) {
+	private void validatePasswordIsCorrect(Password inputPassword, Password originPassword) {
+		if (!passwordEncoder.isMatch(inputPassword.getPasswordValue(), originPassword.getPasswordValue())) {
 			throw new BusinessException(ErrorCode.LOGIN_FAIL);
 		}
 	}
@@ -41,8 +42,8 @@ public class UserService {
 		validateDuplicateEmail(signupRequest.email());
 		validateDuplicateLoginId(signupRequest.loginId());
 
-		String encryptPassword = passwordEncoder.encrypt(signupRequest.password());
-		User user = signupRequest.toEntity(encryptPassword);
+		signupRequest.password().encryptPassword(passwordEncoder);
+		User user = signupRequest.toEntity();
 
 		userRepository.save(user);
 

--- a/src/main/java/com/kongtoon/domain/view/repository/cache/ViewMapCache.java
+++ b/src/main/java/com/kongtoon/domain/view/repository/cache/ViewMapCache.java
@@ -23,7 +23,7 @@ public class ViewMapCache implements ViewCache {
 
     @Override
     public void save(User user, Episode episode) {
-        String subKey = createKey(user.getLoginId(), episode.getId());
+        String subKey = createKey(user.getLoginId().getIdValue(), episode.getId());
         Map<String, View> viewsForInsert = viewCache.get(INSERT_MAP_MAIN_KEY);
         Map<String, View> viewsForUpdate = viewCache.get(UPDATE_MAP_MAIN_KEY);
 

--- a/src/test/java/com/kongtoon/domain/comic/controller/ComicControllerTest.java
+++ b/src/test/java/com/kongtoon/domain/comic/controller/ComicControllerTest.java
@@ -15,6 +15,7 @@ import com.kongtoon.domain.comic.model.Comic;
 import com.kongtoon.domain.comic.model.dto.request.ComicRequest;
 import com.kongtoon.domain.comic.repository.ComicRepository;
 import com.kongtoon.domain.user.dto.UserAuthDTO;
+import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.model.UserAuthority;
 import com.kongtoon.domain.user.repository.UserRepository;
@@ -199,7 +200,7 @@ class ComicControllerTest {
         // given
         ComicRequest comicRequest = createComicRequest();
         MockHttpSession session = new MockHttpSession();
-        session.setAttribute(UserSessionUtil.LOGIN_MEMBER_ID, new UserAuthDTO(0L, "notExistLoginId", UserAuthority.AUTHOR));
+        session.setAttribute(UserSessionUtil.LOGIN_MEMBER_ID, new UserAuthDTO(0L, new LoginId("notExistLoginId"), UserAuthority.AUTHOR));
 
         MockMultipartFile thumbnailRequestThumbnailImageSmallFieldImage
                 = createMockMultipartFile(THUMBNAIL_REQUEST_THUMBNAIL_IMAGE_SMALL_FIELD, "small_thumbnail_image.png", "image/png");

--- a/src/test/java/com/kongtoon/domain/comic/service/ComicModifyServiceTest.java
+++ b/src/test/java/com/kongtoon/domain/comic/service/ComicModifyServiceTest.java
@@ -14,6 +14,7 @@ import com.kongtoon.domain.comic.model.ThumbnailType;
 import com.kongtoon.domain.comic.model.dto.request.ComicRequest;
 import com.kongtoon.domain.comic.repository.ComicRepository;
 import com.kongtoon.domain.comic.repository.ThumbnailRepository;
+import com.kongtoon.domain.user.model.Email;
 import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.repository.UserRepository;
@@ -65,7 +66,8 @@ class ComicModifyServiceTest {
         // given
         ComicRequest comicRequest = createComicRequest();
         LoginId loginId = new LoginId("loginId");
-        User user = createUser("email@email.com", loginId);
+        Email email = new Email("email@email.com");
+        User user = createUser(email, loginId);
         Author author = createAuthor(user);
         String uploadedThumbnailImageUrl1 = "uploadedThumbnailImageUrl1";
         String uploadedThumbnailImageUrl2 = "uploadedThumbnailImageUrl2";
@@ -124,7 +126,8 @@ class ComicModifyServiceTest {
         // given
         ComicRequest comicRequest = createComicRequest();
         LoginId loginId = new LoginId("loginId");
-        User user = createUser("email@email.com", loginId);
+        Email email = new Email("email@email.com");
+        User user = createUser(email, loginId);
 
         when(userRepository.findByLoginId(loginId))
                 .thenReturn(Optional.of(user));
@@ -146,7 +149,8 @@ class ComicModifyServiceTest {
         // given
         ComicRequest comicRequest = createComicRequest();
         LoginId loginId = new LoginId("loginId");
-        User user = createUser("email@email.com", loginId);
+        Email email = new Email("email@email.com");
+        User user = createUser(email, loginId);
         Author author = createAuthor(user);
 
         when(userRepository.findByLoginId(loginId))

--- a/src/test/java/com/kongtoon/domain/comic/service/ComicModifyServiceTest.java
+++ b/src/test/java/com/kongtoon/domain/comic/service/ComicModifyServiceTest.java
@@ -14,6 +14,7 @@ import com.kongtoon.domain.comic.model.ThumbnailType;
 import com.kongtoon.domain.comic.model.dto.request.ComicRequest;
 import com.kongtoon.domain.comic.repository.ComicRepository;
 import com.kongtoon.domain.comic.repository.ThumbnailRepository;
+import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -63,7 +64,7 @@ class ComicModifyServiceTest {
 
         // given
         ComicRequest comicRequest = createComicRequest();
-        String loginId = "loginId";
+        LoginId loginId = new LoginId("loginId");
         User user = createUser("email@email.com", loginId);
         Author author = createAuthor(user);
         String uploadedThumbnailImageUrl1 = "uploadedThumbnailImageUrl1";
@@ -105,7 +106,7 @@ class ComicModifyServiceTest {
 
         // given
         ComicRequest comicRequest = createComicRequest();
-        String loginId = "loginId";
+        LoginId loginId = new LoginId("loginId");
 
         when(userRepository.findByLoginId(loginId))
                 .thenReturn(Optional.empty());
@@ -122,7 +123,7 @@ class ComicModifyServiceTest {
 
         // given
         ComicRequest comicRequest = createComicRequest();
-        String loginId = "loginId";
+        LoginId loginId = new LoginId("loginId");
         User user = createUser("email@email.com", loginId);
 
         when(userRepository.findByLoginId(loginId))
@@ -144,7 +145,7 @@ class ComicModifyServiceTest {
 
         // given
         ComicRequest comicRequest = createComicRequest();
-        String loginId = "loginId";
+        LoginId loginId = new LoginId("loginId");
         User user = createUser("email@email.com", loginId);
         Author author = createAuthor(user);
 

--- a/src/test/java/com/kongtoon/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/kongtoon/domain/user/controller/UserControllerTest.java
@@ -9,10 +9,7 @@ import com.kongtoon.common.session.UserSessionUtil;
 import com.kongtoon.domain.user.dto.UserAuthDTO;
 import com.kongtoon.domain.user.dto.request.LoginRequest;
 import com.kongtoon.domain.user.dto.request.SignupRequest;
-import com.kongtoon.domain.user.model.Email;
-import com.kongtoon.domain.user.model.LoginId;
-import com.kongtoon.domain.user.model.User;
-import com.kongtoon.domain.user.model.UserAuthority;
+import com.kongtoon.domain.user.model.*;
 import com.kongtoon.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -64,13 +61,15 @@ class UserControllerTest {
 	private static final String SIGNUP_EMAIL_ADDRESS_REQ_FIELD = "email.address";
 	private static final String SIGNUP_NICKNAME_REQ_FIELD = "nickname";
 	private static final String SIGNUP_PASSWORD_REQ_FIELD = "password";
+	private static final String SIGNUP_PASSWORD_VALUE_REQ_FIELD = "password.passwordValue";
 	private static final String SIGNUP_LOGIN_ID_REQ_DESCRIPTION = "로그인ID 정보";
 	private static final String SIGNUP_LOGIN_ID_ID_VALUE_REQ_DESCRIPTION = "로그인ID";
 	private static final String SIGNUP_NAME_REQ_DESCRIPTION = "이름";
 	private static final String SIGNUP_EMAIL_REQ_DESCRIPTION = "이메일 정보";
 	private static final String SIGNUP_EMAIL_ADDRESS_REQ_DESCRIPTION = "이메일 주소";
 	private static final String SIGNUP_NICKNAME_REQ_DESCRIPTION = "닉네임";
-	private static final String SIGNUP_PASSWORD_REQ_DESCRIPTION = "비밀번호";
+	private static final String SIGNUP_PASSWORD_REQ_DESCRIPTION = "비밀번호 정보";
+	private static final String SIGNUP_PASSWORD_VALUE_REQ_DESCRIPTION = "비밀번호";
 
 	private static final String CHECK_LOGIN_ID_DUP_TAG = "로그인ID 중복 체크";
 	private static final String CHECK_LOGIN_ID_DUP_SUMMARY = "로그인ID 중복 체크 성공, 실패 APIs";
@@ -145,7 +144,8 @@ class UserControllerTest {
 								fieldWithPath(SIGNUP_EMAIL_REQ_FIELD).type(JsonFieldType.OBJECT).description(SIGNUP_EMAIL_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_EMAIL_ADDRESS_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_EMAIL_ADDRESS_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_NICKNAME_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_NICKNAME_REQ_DESCRIPTION),
-								fieldWithPath(SIGNUP_PASSWORD_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_PASSWORD_REQ_DESCRIPTION)
+								fieldWithPath(SIGNUP_PASSWORD_REQ_FIELD).type(JsonFieldType.OBJECT).description(SIGNUP_PASSWORD_REQ_DESCRIPTION),
+								fieldWithPath(SIGNUP_PASSWORD_VALUE_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_PASSWORD_VALUE_REQ_DESCRIPTION)
 						),
 						responseHeaders(
 								headerWithName("Location").description("저장된 회원 URL")
@@ -199,7 +199,8 @@ class UserControllerTest {
 								fieldWithPath(SIGNUP_EMAIL_REQ_FIELD).type(JsonFieldType.OBJECT).description(SIGNUP_EMAIL_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_EMAIL_ADDRESS_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_EMAIL_ADDRESS_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_NICKNAME_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_NICKNAME_REQ_DESCRIPTION),
-								fieldWithPath(SIGNUP_PASSWORD_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_PASSWORD_REQ_DESCRIPTION)
+								fieldWithPath(SIGNUP_PASSWORD_REQ_FIELD).type(JsonFieldType.OBJECT).description(SIGNUP_PASSWORD_REQ_DESCRIPTION),
+								fieldWithPath(SIGNUP_PASSWORD_VALUE_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_PASSWORD_VALUE_REQ_DESCRIPTION)
 						),
 						responseFields(
 								fieldWithPath(ERROR_MESSAGE_FIELD).type(JsonFieldType.STRING).description(ERROR_MESSAGE_DESCRIPTION),
@@ -255,7 +256,8 @@ class UserControllerTest {
 								fieldWithPath(SIGNUP_EMAIL_REQ_FIELD).type(JsonFieldType.OBJECT).description(SIGNUP_EMAIL_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_EMAIL_ADDRESS_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_EMAIL_ADDRESS_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_NICKNAME_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_NICKNAME_REQ_DESCRIPTION),
-								fieldWithPath(SIGNUP_PASSWORD_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_PASSWORD_REQ_DESCRIPTION)
+								fieldWithPath(SIGNUP_PASSWORD_REQ_FIELD).type(JsonFieldType.OBJECT).description(SIGNUP_PASSWORD_REQ_DESCRIPTION),
+								fieldWithPath(SIGNUP_PASSWORD_VALUE_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_PASSWORD_VALUE_REQ_DESCRIPTION)
 						),
 						responseFields(
 								fieldWithPath(ERROR_MESSAGE_FIELD).type(JsonFieldType.STRING).description(ERROR_MESSAGE_DESCRIPTION),
@@ -308,7 +310,8 @@ class UserControllerTest {
 								fieldWithPath(SIGNUP_EMAIL_REQ_FIELD).type(JsonFieldType.OBJECT).description(SIGNUP_EMAIL_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_EMAIL_ADDRESS_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_EMAIL_ADDRESS_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_NICKNAME_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_NICKNAME_REQ_DESCRIPTION),
-								fieldWithPath(SIGNUP_PASSWORD_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_PASSWORD_REQ_DESCRIPTION)
+								fieldWithPath(SIGNUP_PASSWORD_REQ_FIELD).type(JsonFieldType.OBJECT).description(SIGNUP_PASSWORD_REQ_DESCRIPTION),
+								fieldWithPath(SIGNUP_PASSWORD_VALUE_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_PASSWORD_VALUE_REQ_DESCRIPTION)
 						),
 						responseFields(
 								fieldWithPath(ERROR_MESSAGE_FIELD).type(JsonFieldType.STRING).description(ERROR_MESSAGE_DESCRIPTION),
@@ -477,7 +480,8 @@ class UserControllerTest {
 		// given
 		LoginRequest loginRequest = createLoginRequest();
 		Email email = new Email("email@email.com");
-		User user = createUser(email, loginRequest.loginId(), passwordEncoder.encrypt(loginRequest.password()));
+		Password password = new Password(passwordEncoder.encrypt(loginRequest.password().getPasswordValue()));
+		User user = createUser(email, loginRequest.loginId(), password);
 
 		userRepository.save(user);
 
@@ -502,7 +506,8 @@ class UserControllerTest {
 						requestFields(
 								fieldWithPath(LOGIN_LOGIN_ID_REQ_FIELD).type(JsonFieldType.OBJECT).description(LOGIN_LOGIN_ID_REQ_DESCRIPTION),
 								fieldWithPath(LOGIN_LOGIN_ID_ID_VALUE_REQ_FIELD).type(JsonFieldType.STRING).description(LOGIN_LOGIN_ID_ID_VALUE_REQ_DESCRIPTION),
-								fieldWithPath(LOGIN_PASSWORD_REQ_FIELD).type(JsonFieldType.STRING).description(LOGIN_PASSWORD_REQ_DESCRIPTION)
+								fieldWithPath(SIGNUP_PASSWORD_REQ_FIELD).type(JsonFieldType.OBJECT).description(SIGNUP_PASSWORD_REQ_DESCRIPTION),
+								fieldWithPath(SIGNUP_PASSWORD_VALUE_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_PASSWORD_VALUE_REQ_DESCRIPTION)
 						)
 				)
 		);
@@ -538,7 +543,8 @@ class UserControllerTest {
 						requestFields(
 								fieldWithPath(LOGIN_LOGIN_ID_REQ_FIELD).type(JsonFieldType.OBJECT).description(LOGIN_LOGIN_ID_REQ_DESCRIPTION),
 								fieldWithPath(LOGIN_LOGIN_ID_ID_VALUE_REQ_FIELD).type(JsonFieldType.STRING).description(LOGIN_LOGIN_ID_ID_VALUE_REQ_DESCRIPTION),
-								fieldWithPath(LOGIN_PASSWORD_REQ_FIELD).type(JsonFieldType.STRING).description(LOGIN_PASSWORD_REQ_DESCRIPTION)
+								fieldWithPath(SIGNUP_PASSWORD_REQ_FIELD).type(JsonFieldType.OBJECT).description(SIGNUP_PASSWORD_REQ_DESCRIPTION),
+								fieldWithPath(SIGNUP_PASSWORD_VALUE_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_PASSWORD_VALUE_REQ_DESCRIPTION)
 						),
 						responseFields(
 								fieldWithPath(ERROR_MESSAGE_FIELD).type(JsonFieldType.STRING).description(ERROR_MESSAGE_DESCRIPTION),
@@ -555,7 +561,8 @@ class UserControllerTest {
 		// given
 		LoginRequest loginRequest = createLoginRequest();
 		Email email = new Email("email@email.com");
-		User user = createUser(email, loginRequest.loginId(), passwordEncoder.encrypt("mismatchPassword"));
+		Password mismatchPassword = new Password(passwordEncoder.encrypt("mismatchPassword"));
+		User user = createUser(email, loginRequest.loginId(), mismatchPassword);
 
 		userRepository.save(user);
 

--- a/src/test/java/com/kongtoon/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/kongtoon/domain/user/controller/UserControllerTest.java
@@ -9,6 +9,7 @@ import com.kongtoon.common.session.UserSessionUtil;
 import com.kongtoon.domain.user.dto.UserAuthDTO;
 import com.kongtoon.domain.user.dto.request.LoginRequest;
 import com.kongtoon.domain.user.dto.request.SignupRequest;
+import com.kongtoon.domain.user.model.Email;
 import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.model.UserAuthority;
@@ -16,7 +17,7 @@ import com.kongtoon.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -31,6 +32,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.kongtoon.utils.TestConst.*;
@@ -59,12 +61,14 @@ class UserControllerTest {
 	private static final String SIGNUP_LOGIN_ID_ID_VALUE_REQ_FIELD = "loginId.idValue";
 	private static final String SIGNUP_NAME_REQ_FIELD = "name";
 	private static final String SIGNUP_EMAIL_REQ_FIELD = "email";
+	private static final String SIGNUP_EMAIL_ADDRESS_REQ_FIELD = "email.address";
 	private static final String SIGNUP_NICKNAME_REQ_FIELD = "nickname";
 	private static final String SIGNUP_PASSWORD_REQ_FIELD = "password";
 	private static final String SIGNUP_LOGIN_ID_REQ_DESCRIPTION = "로그인ID 정보";
-	private static final String SIGNUP_LOGIN_ID_ID_VALUE_REQ_DESCRIPTION = "로그인ID 정보";
+	private static final String SIGNUP_LOGIN_ID_ID_VALUE_REQ_DESCRIPTION = "로그인ID";
 	private static final String SIGNUP_NAME_REQ_DESCRIPTION = "이름";
-	private static final String SIGNUP_EMAIL_REQ_DESCRIPTION = "이메일";
+	private static final String SIGNUP_EMAIL_REQ_DESCRIPTION = "이메일 정보";
+	private static final String SIGNUP_EMAIL_ADDRESS_REQ_DESCRIPTION = "이메일 주소";
 	private static final String SIGNUP_NICKNAME_REQ_DESCRIPTION = "닉네임";
 	private static final String SIGNUP_PASSWORD_REQ_DESCRIPTION = "비밀번호";
 
@@ -138,7 +142,8 @@ class UserControllerTest {
 								fieldWithPath(SIGNUP_LOGIN_ID_REQ_FIELD).type(JsonFieldType.OBJECT).description(SIGNUP_LOGIN_ID_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_LOGIN_ID_ID_VALUE_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_LOGIN_ID_ID_VALUE_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_NAME_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_NAME_REQ_DESCRIPTION),
-								fieldWithPath(SIGNUP_EMAIL_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_EMAIL_REQ_DESCRIPTION),
+								fieldWithPath(SIGNUP_EMAIL_REQ_FIELD).type(JsonFieldType.OBJECT).description(SIGNUP_EMAIL_REQ_DESCRIPTION),
+								fieldWithPath(SIGNUP_EMAIL_ADDRESS_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_EMAIL_ADDRESS_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_NICKNAME_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_NICKNAME_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_PASSWORD_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_PASSWORD_REQ_DESCRIPTION)
 						),
@@ -153,7 +158,7 @@ class UserControllerTest {
 	@DisplayName("회원가입 시 이메일 중복으로 실패한다.")
 	void signUpDuplicatedEmailFail() throws Exception {
 		// given
-		String savedEmail = "savedEmail@email.com";
+		Email savedEmail = new Email("savedEmail@email.com");
 		LoginId savedLoginId = new LoginId("savedLoginId");
 
 		User user = createUser(savedEmail, savedLoginId);
@@ -191,7 +196,8 @@ class UserControllerTest {
 								fieldWithPath(SIGNUP_LOGIN_ID_REQ_FIELD).type(JsonFieldType.OBJECT).description(SIGNUP_LOGIN_ID_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_LOGIN_ID_ID_VALUE_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_LOGIN_ID_ID_VALUE_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_NAME_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_NAME_REQ_DESCRIPTION),
-								fieldWithPath(SIGNUP_EMAIL_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_EMAIL_REQ_DESCRIPTION),
+								fieldWithPath(SIGNUP_EMAIL_REQ_FIELD).type(JsonFieldType.OBJECT).description(SIGNUP_EMAIL_REQ_DESCRIPTION),
+								fieldWithPath(SIGNUP_EMAIL_ADDRESS_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_EMAIL_ADDRESS_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_NICKNAME_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_NICKNAME_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_PASSWORD_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_PASSWORD_REQ_DESCRIPTION)
 						),
@@ -208,13 +214,13 @@ class UserControllerTest {
 	@DisplayName("회원가입 시 로그인 아이디 중복으로 실패한다.")
 	void signUpDuplicatedLoginIdFail() throws Exception {
 		// given
-		String savedEmail = "savedEmail@email.com";
+		Email savedEmail = new Email("savedEmail@email.com");
 		LoginId savedLoginId = new LoginId("savedLoginId");
 
 		User user = createUser(savedEmail, savedLoginId);
 		userRepository.save(user);
 
-		String newEmail = "newEmail@email.com";
+		Email newEmail = new Email("newEmail@email.com");
 		SignupRequest signupRequest = createSignupRequest(savedLoginId, newEmail);
 
 		long beforeUserCount = userRepository.count();
@@ -246,7 +252,8 @@ class UserControllerTest {
 								fieldWithPath(SIGNUP_LOGIN_ID_REQ_FIELD).type(JsonFieldType.OBJECT).description(SIGNUP_LOGIN_ID_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_LOGIN_ID_ID_VALUE_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_LOGIN_ID_ID_VALUE_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_NAME_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_NAME_REQ_DESCRIPTION),
-								fieldWithPath(SIGNUP_EMAIL_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_EMAIL_REQ_DESCRIPTION),
+								fieldWithPath(SIGNUP_EMAIL_REQ_FIELD).type(JsonFieldType.OBJECT).description(SIGNUP_EMAIL_REQ_DESCRIPTION),
+								fieldWithPath(SIGNUP_EMAIL_ADDRESS_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_EMAIL_ADDRESS_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_NICKNAME_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_NICKNAME_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_PASSWORD_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_PASSWORD_REQ_DESCRIPTION)
 						),
@@ -260,9 +267,9 @@ class UserControllerTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {"notEmail", "notEmail@email", "notEmail.com"})
+	@MethodSource("invalidEmails")
 	@DisplayName("회원가입 시 형식에 맞지 않은 이메일인 경우 실패한다.")
-	void signUpInvalidEmailFail(String invalidEmail) throws Exception {
+	void signUpInvalidEmailFail(Email invalidEmail) throws Exception {
 
 		// given
 		LoginId validLoginId = new LoginId("loginId");
@@ -298,7 +305,8 @@ class UserControllerTest {
 								fieldWithPath(SIGNUP_LOGIN_ID_REQ_FIELD).type(JsonFieldType.OBJECT).description(SIGNUP_LOGIN_ID_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_LOGIN_ID_ID_VALUE_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_LOGIN_ID_ID_VALUE_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_NAME_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_NAME_REQ_DESCRIPTION),
-								fieldWithPath(SIGNUP_EMAIL_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_EMAIL_REQ_DESCRIPTION),
+								fieldWithPath(SIGNUP_EMAIL_REQ_FIELD).type(JsonFieldType.OBJECT).description(SIGNUP_EMAIL_REQ_DESCRIPTION),
+								fieldWithPath(SIGNUP_EMAIL_ADDRESS_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_EMAIL_ADDRESS_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_NICKNAME_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_NICKNAME_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_PASSWORD_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_PASSWORD_REQ_DESCRIPTION)
 						),
@@ -310,6 +318,14 @@ class UserControllerTest {
 								fieldWithPath(INPUT_ERROR_INFOS_FIELD_FIELD).type(JsonFieldType.STRING).description(INPUT_ERROR_INFOS_FIELD_DESCRIPTION)
 						)
 				)
+		);
+	}
+
+	private static Stream<Email> invalidEmails() {
+		return Stream.of(
+				new Email("notEmail"),
+				new Email("notEmail@email"),
+				new Email("notEmail.com")
 		);
 	}
 
@@ -349,7 +365,8 @@ class UserControllerTest {
 
 		// given
 		LoginId loginId = new LoginId("dupLoginId");
-		User user = createUser("email@email.com", loginId);
+		Email email = new Email("email@email.com");
+		User user = createUser(email, loginId);
 		userRepository.save(user);
 
 		// when
@@ -418,13 +435,13 @@ class UserControllerTest {
 	void checkDuplicateEmailFail() throws Exception {
 
 		// given
-		String email = "dupEmail@email.com";
+		Email email = new Email("dupEmail@email.com");
 		LoginId loginId = new LoginId("loginId");
 		User user = createUser(email, loginId);
 		userRepository.save(user);
 
 		// when
-		ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.post("/users/signup/check-duplicate-email/{email}", email));
+		ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.post("/users/signup/check-duplicate-email/{email}", email.getAddress()));
 
 		// then
 		resultActions.andExpect(status().isConflict());
@@ -459,7 +476,8 @@ class UserControllerTest {
 	void loginSuccess() throws Exception {
 		// given
 		LoginRequest loginRequest = createLoginRequest();
-		User user = createUser("email@email.com", loginRequest.loginId(), passwordEncoder.encrypt(loginRequest.password()));
+		Email email = new Email("email@email.com");
+		User user = createUser(email, loginRequest.loginId(), passwordEncoder.encrypt(loginRequest.password()));
 
 		userRepository.save(user);
 
@@ -536,7 +554,8 @@ class UserControllerTest {
 	void loginPasswordMismatchFail() throws Exception {
 		// given
 		LoginRequest loginRequest = createLoginRequest();
-		User user = createUser("email@email.com", loginRequest.loginId(), passwordEncoder.encrypt("mismatchPassword"));
+		Email email = new Email("email@email.com");
+		User user = createUser(email, loginRequest.loginId(), passwordEncoder.encrypt("mismatchPassword"));
 
 		userRepository.save(user);
 

--- a/src/test/java/com/kongtoon/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/kongtoon/domain/user/controller/UserControllerTest.java
@@ -9,6 +9,7 @@ import com.kongtoon.common.session.UserSessionUtil;
 import com.kongtoon.domain.user.dto.UserAuthDTO;
 import com.kongtoon.domain.user.dto.request.LoginRequest;
 import com.kongtoon.domain.user.dto.request.SignupRequest;
+import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.model.UserAuthority;
 import com.kongtoon.domain.user.repository.UserRepository;
@@ -55,11 +56,13 @@ class UserControllerTest {
 	private static final String SIGNUP_SUMMARY = "회원가입 성공, 실패 APIs";
 	private static final String SIGNUP_REQ_SCHEMA = "SignupRequest";
 	private static final String SIGNUP_LOGIN_ID_REQ_FIELD = "loginId";
+	private static final String SIGNUP_LOGIN_ID_ID_VALUE_REQ_FIELD = "loginId.idValue";
 	private static final String SIGNUP_NAME_REQ_FIELD = "name";
 	private static final String SIGNUP_EMAIL_REQ_FIELD = "email";
 	private static final String SIGNUP_NICKNAME_REQ_FIELD = "nickname";
 	private static final String SIGNUP_PASSWORD_REQ_FIELD = "password";
-	private static final String SIGNUP_LOGIN_ID_REQ_DESCRIPTION = "로그인ID";
+	private static final String SIGNUP_LOGIN_ID_REQ_DESCRIPTION = "로그인ID 정보";
+	private static final String SIGNUP_LOGIN_ID_ID_VALUE_REQ_DESCRIPTION = "로그인ID 정보";
 	private static final String SIGNUP_NAME_REQ_DESCRIPTION = "이름";
 	private static final String SIGNUP_EMAIL_REQ_DESCRIPTION = "이메일";
 	private static final String SIGNUP_NICKNAME_REQ_DESCRIPTION = "닉네임";
@@ -81,8 +84,10 @@ class UserControllerTest {
 	private static final String LOGIN_SUMMARY = "로그인 성공, 실패 APIs";
 	private static final String LOGIN_REQ_SCHEMA = "LoginRequest";
 	private static final String LOGIN_LOGIN_ID_REQ_FIELD = "loginId";
+	private static final String LOGIN_LOGIN_ID_ID_VALUE_REQ_FIELD = "loginId.idValue";
 	private static final String LOGIN_PASSWORD_REQ_FIELD = "password";
-	private static final String LOGIN_LOGIN_ID_REQ_DESCRIPTION = "로그인ID";
+	private static final String LOGIN_LOGIN_ID_REQ_DESCRIPTION = "로그인ID 정보";
+	private static final String LOGIN_LOGIN_ID_ID_VALUE_REQ_DESCRIPTION = "로그인ID";
 	private static final String LOGIN_PASSWORD_REQ_DESCRIPTION = "비밀번호";
 
 	private static final String LOGOUT_TAG = "로그아웃";
@@ -130,7 +135,8 @@ class UserControllerTest {
 						preprocessRequest(prettyPrint()),
 						preprocessResponse(prettyPrint()),
 						requestFields(
-								fieldWithPath(SIGNUP_LOGIN_ID_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_LOGIN_ID_REQ_DESCRIPTION),
+								fieldWithPath(SIGNUP_LOGIN_ID_REQ_FIELD).type(JsonFieldType.OBJECT).description(SIGNUP_LOGIN_ID_REQ_DESCRIPTION),
+								fieldWithPath(SIGNUP_LOGIN_ID_ID_VALUE_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_LOGIN_ID_ID_VALUE_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_NAME_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_NAME_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_EMAIL_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_EMAIL_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_NICKNAME_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_NICKNAME_REQ_DESCRIPTION),
@@ -148,12 +154,12 @@ class UserControllerTest {
 	void signUpDuplicatedEmailFail() throws Exception {
 		// given
 		String savedEmail = "savedEmail@email.com";
-		String savedLoginId = "savedLoginId";
+		LoginId savedLoginId = new LoginId("savedLoginId");
 
 		User user = createUser(savedEmail, savedLoginId);
 		userRepository.save(user);
 
-		String newLoginId = "newLoginId";
+		LoginId newLoginId = new LoginId("newLoginId");
 		SignupRequest signupRequest = createSignupRequest(newLoginId, savedEmail);
 
 		long beforeUserCount = userRepository.count();
@@ -182,7 +188,8 @@ class UserControllerTest {
 						preprocessRequest(prettyPrint()),
 						preprocessResponse(prettyPrint()),
 						requestFields(
-								fieldWithPath(SIGNUP_LOGIN_ID_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_LOGIN_ID_REQ_DESCRIPTION),
+								fieldWithPath(SIGNUP_LOGIN_ID_REQ_FIELD).type(JsonFieldType.OBJECT).description(SIGNUP_LOGIN_ID_REQ_DESCRIPTION),
+								fieldWithPath(SIGNUP_LOGIN_ID_ID_VALUE_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_LOGIN_ID_ID_VALUE_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_NAME_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_NAME_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_EMAIL_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_EMAIL_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_NICKNAME_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_NICKNAME_REQ_DESCRIPTION),
@@ -202,7 +209,7 @@ class UserControllerTest {
 	void signUpDuplicatedLoginIdFail() throws Exception {
 		// given
 		String savedEmail = "savedEmail@email.com";
-		String savedLoginId = "savedLoginId";
+		LoginId savedLoginId = new LoginId("savedLoginId");
 
 		User user = createUser(savedEmail, savedLoginId);
 		userRepository.save(user);
@@ -236,7 +243,8 @@ class UserControllerTest {
 						preprocessRequest(prettyPrint()),
 						preprocessResponse(prettyPrint()),
 						requestFields(
-								fieldWithPath(SIGNUP_LOGIN_ID_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_LOGIN_ID_REQ_DESCRIPTION),
+								fieldWithPath(SIGNUP_LOGIN_ID_REQ_FIELD).type(JsonFieldType.OBJECT).description(SIGNUP_LOGIN_ID_REQ_DESCRIPTION),
+								fieldWithPath(SIGNUP_LOGIN_ID_ID_VALUE_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_LOGIN_ID_ID_VALUE_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_NAME_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_NAME_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_EMAIL_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_EMAIL_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_NICKNAME_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_NICKNAME_REQ_DESCRIPTION),
@@ -257,7 +265,7 @@ class UserControllerTest {
 	void signUpInvalidEmailFail(String invalidEmail) throws Exception {
 
 		// given
-		String validLoginId = "loginId";
+		LoginId validLoginId = new LoginId("loginId");
 		SignupRequest signupRequest = createSignupRequest(validLoginId, invalidEmail);
 		long beforeUserCount = userRepository.count();
 
@@ -287,7 +295,8 @@ class UserControllerTest {
 						preprocessRequest(prettyPrint()),
 						preprocessResponse(prettyPrint()),
 						requestFields(
-								fieldWithPath(SIGNUP_LOGIN_ID_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_LOGIN_ID_REQ_DESCRIPTION),
+								fieldWithPath(SIGNUP_LOGIN_ID_REQ_FIELD).type(JsonFieldType.OBJECT).description(SIGNUP_LOGIN_ID_REQ_DESCRIPTION),
+								fieldWithPath(SIGNUP_LOGIN_ID_ID_VALUE_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_LOGIN_ID_ID_VALUE_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_NAME_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_NAME_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_EMAIL_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_EMAIL_REQ_DESCRIPTION),
 								fieldWithPath(SIGNUP_NICKNAME_REQ_FIELD).type(JsonFieldType.STRING).description(SIGNUP_NICKNAME_REQ_DESCRIPTION),
@@ -339,12 +348,12 @@ class UserControllerTest {
 	void checkDuplicateLoginIdFail() throws Exception {
 
 		// given
-		String loginId = "dupLoginId";
+		LoginId loginId = new LoginId("dupLoginId");
 		User user = createUser("email@email.com", loginId);
 		userRepository.save(user);
 
 		// when
-		ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.post("/users/signup/check-duplicate-id/{loginId}", loginId));
+		ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.post("/users/signup/check-duplicate-id/{loginId}", loginId.getIdValue()));
 
 		// then
 		resultActions.andExpect(status().isConflict());
@@ -410,7 +419,8 @@ class UserControllerTest {
 
 		// given
 		String email = "dupEmail@email.com";
-		User user = createUser(email, "loginId");
+		LoginId loginId = new LoginId("loginId");
+		User user = createUser(email, loginId);
 		userRepository.save(user);
 
 		// when
@@ -472,7 +482,8 @@ class UserControllerTest {
 						preprocessRequest(prettyPrint()),
 						preprocessResponse(prettyPrint()),
 						requestFields(
-								fieldWithPath(LOGIN_LOGIN_ID_REQ_FIELD).type(JsonFieldType.STRING).description(LOGIN_LOGIN_ID_REQ_DESCRIPTION),
+								fieldWithPath(LOGIN_LOGIN_ID_REQ_FIELD).type(JsonFieldType.OBJECT).description(LOGIN_LOGIN_ID_REQ_DESCRIPTION),
+								fieldWithPath(LOGIN_LOGIN_ID_ID_VALUE_REQ_FIELD).type(JsonFieldType.STRING).description(LOGIN_LOGIN_ID_ID_VALUE_REQ_DESCRIPTION),
 								fieldWithPath(LOGIN_PASSWORD_REQ_FIELD).type(JsonFieldType.STRING).description(LOGIN_PASSWORD_REQ_DESCRIPTION)
 						)
 				)
@@ -507,7 +518,8 @@ class UserControllerTest {
 						preprocessRequest(prettyPrint()),
 						preprocessResponse(prettyPrint()),
 						requestFields(
-								fieldWithPath(LOGIN_LOGIN_ID_REQ_FIELD).type(JsonFieldType.STRING).description(LOGIN_LOGIN_ID_REQ_DESCRIPTION),
+								fieldWithPath(LOGIN_LOGIN_ID_REQ_FIELD).type(JsonFieldType.OBJECT).description(LOGIN_LOGIN_ID_REQ_DESCRIPTION),
+								fieldWithPath(LOGIN_LOGIN_ID_ID_VALUE_REQ_FIELD).type(JsonFieldType.STRING).description(LOGIN_LOGIN_ID_ID_VALUE_REQ_DESCRIPTION),
 								fieldWithPath(LOGIN_PASSWORD_REQ_FIELD).type(JsonFieldType.STRING).description(LOGIN_PASSWORD_REQ_DESCRIPTION)
 						),
 						responseFields(
@@ -557,9 +569,9 @@ class UserControllerTest {
 	@Test
 	@DisplayName("로그아웃에 성공한다.")
 	void logoutSuccess() throws Exception {
-
 		// given
-		UserAuthDTO user = new UserAuthDTO(1L, "loginId", UserAuthority.USER);
+		LoginId loginId = new LoginId("loginId");
+		UserAuthDTO user = new UserAuthDTO(1L, loginId, UserAuthority.USER);
 		MockHttpSession session = new MockHttpSession();
 		session.setAttribute(UserSessionUtil.LOGIN_MEMBER_ID, user);
 

--- a/src/test/java/com/kongtoon/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/kongtoon/domain/user/controller/UserControllerTest.java
@@ -286,7 +286,7 @@ class UserControllerTest {
 		resultActions.andExpect(jsonPath(ERROR_MESSAGE_FIELD).value(ErrorCode.INVALID_INPUT.getMessage()));
 		resultActions.andExpect(jsonPath(ERROR_CODE_FIELD).value(ErrorCode.INVALID_INPUT.name()));
 		resultActions.andExpect(jsonPath(INPUT_ERROR_INFOS_MESSAGE_FIELD).value("잘못된 형식의 이메일입니다."));
-		resultActions.andExpect(jsonPath(INPUT_ERROR_INFOS_FIELD_FIELD).value(SIGNUP_EMAIL_REQ_FIELD));
+		resultActions.andExpect(jsonPath(INPUT_ERROR_INFOS_FIELD_FIELD).value(SIGNUP_EMAIL_ADDRESS_REQ_FIELD));
 
 		long afterUserCount = userRepository.count();
 		assertThat(beforeUserCount).isSameAs(afterUserCount);

--- a/src/test/java/com/kongtoon/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/kongtoon/domain/user/service/UserServiceTest.java
@@ -6,6 +6,7 @@ import com.kongtoon.common.security.PasswordEncoder;
 import com.kongtoon.domain.user.dto.UserAuthDTO;
 import com.kongtoon.domain.user.dto.request.LoginRequest;
 import com.kongtoon.domain.user.dto.request.SignupRequest;
+import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -39,7 +40,7 @@ class UserServiceTest {
 	@DisplayName("회원가입에 성공한다.")
 	void signupSuccess() {
 		// given
-		String loginId = "loginId";
+		LoginId loginId = new LoginId("loginId");
 		String name = "name";
 		String email = "email@email.com";
 		String nickname = "nickname";
@@ -70,7 +71,7 @@ class UserServiceTest {
 	@DisplayName("회원가입 시 이메일 중복으로 실패한다.")
 	void signUpDuplicatedEmailFail() {
 		// given
-		String loginId = "loginId";
+		LoginId loginId = new LoginId("loginId");
 		String name = "name";
 		String email = "email@email.com";
 		String nickname = "nickname";
@@ -95,7 +96,7 @@ class UserServiceTest {
 	@DisplayName("회원가입 시 로그인 아이디 중복으로 실패한다.")
 	void signUpDuplicatedLoginIdFail() {
 		// given
-		String loginId = "loginId";
+		LoginId loginId = new LoginId("loginId");
 		String name = "name";
 		String email = "email@email.com";
 		String nickname = "nickname";

--- a/src/test/java/com/kongtoon/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/kongtoon/domain/user/service/UserServiceTest.java
@@ -6,6 +6,7 @@ import com.kongtoon.common.security.PasswordEncoder;
 import com.kongtoon.domain.user.dto.UserAuthDTO;
 import com.kongtoon.domain.user.dto.request.LoginRequest;
 import com.kongtoon.domain.user.dto.request.SignupRequest;
+import com.kongtoon.domain.user.model.Email;
 import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.repository.UserRepository;
@@ -42,7 +43,7 @@ class UserServiceTest {
 		// given
 		LoginId loginId = new LoginId("loginId");
 		String name = "name";
-		String email = "email@email.com";
+		Email email = new Email("email@email.com");
 		String nickname = "nickname";
 		String password = "password";
 		String encryptedPassword = "encryptedPassword";
@@ -73,7 +74,7 @@ class UserServiceTest {
 		// given
 		LoginId loginId = new LoginId("loginId");
 		String name = "name";
-		String email = "email@email.com";
+		Email email = new Email("email@email.com");
 		String nickname = "nickname";
 		String password = "password";
 
@@ -98,7 +99,7 @@ class UserServiceTest {
 		// given
 		LoginId loginId = new LoginId("loginId");
 		String name = "name";
-		String email = "email@email.com";
+		Email email = new Email("email@email.com");
 		String nickname = "nickname";
 		String password = "password";
 
@@ -124,8 +125,9 @@ class UserServiceTest {
 	@DisplayName("로그인에 성공한다.")
 	void loginSuccess() {
 		// given
+		Email email = new Email("email@email.com");
 		LoginRequest loginRequest = createLoginRequest();
-		User user = createUser("email@email.com", loginRequest.loginId(), loginRequest.password());
+		User user = createUser(email, loginRequest.loginId(), loginRequest.password());
 		UserAuthDTO correctResult = new UserAuthDTO(0L, user.getLoginId(), user.getAuthority());
 
 		when(userRepository.findByLoginId(loginRequest.loginId()))
@@ -166,8 +168,9 @@ class UserServiceTest {
 	@DisplayName("로그인시 비밀번호 불일치로 실패한다.")
 	void loginPasswordMismatchFail() {
 		// given
+		Email email = new Email("email@email.com");
 		LoginRequest loginRequest = createLoginRequest();
-		User user = createUser("email@email.com", loginRequest.loginId(), "mismatchPassword");
+		User user = createUser(email, loginRequest.loginId(), "mismatchPassword");
 
 		when(userRepository.findByLoginId(loginRequest.loginId()))
 				.thenReturn(Optional.of(user));

--- a/src/test/java/com/kongtoon/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/kongtoon/domain/user/service/UserServiceTest.java
@@ -8,6 +8,7 @@ import com.kongtoon.domain.user.dto.request.LoginRequest;
 import com.kongtoon.domain.user.dto.request.SignupRequest;
 import com.kongtoon.domain.user.model.Email;
 import com.kongtoon.domain.user.model.LoginId;
+import com.kongtoon.domain.user.model.Password;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -45,15 +46,13 @@ class UserServiceTest {
 		String name = "name";
 		Email email = new Email("email@email.com");
 		String nickname = "nickname";
-		String password = "password";
+		Password password = new Password("password");
 		String encryptedPassword = "encryptedPassword";
 
 		SignupRequest signupRequest = new SignupRequest(
 				loginId, name, email, nickname, password
 		);
 
-		when(passwordEncoder.encrypt(password))
-				.thenReturn(encryptedPassword);
 		when(userRepository.existsByLoginId(loginId))
 				.thenReturn(false);
 		when(userRepository.existsByEmail(email))
@@ -76,7 +75,7 @@ class UserServiceTest {
 		String name = "name";
 		Email email = new Email("email@email.com");
 		String nickname = "nickname";
-		String password = "password";
+		Password password = new Password("password");
 
 		SignupRequest signupRequest = new SignupRequest(
 				loginId, name, email, nickname, password
@@ -101,7 +100,7 @@ class UserServiceTest {
 		String name = "name";
 		Email email = new Email("email@email.com");
 		String nickname = "nickname";
-		String password = "password";
+		Password password = new Password("password");
 
 		SignupRequest signupRequest = new SignupRequest(
 				loginId, name, email, nickname, password
@@ -132,7 +131,7 @@ class UserServiceTest {
 
 		when(userRepository.findByLoginId(loginRequest.loginId()))
 				.thenReturn(Optional.of(user));
-		when(passwordEncoder.isMatch(loginRequest.password(), user.getPassword()))
+		when(passwordEncoder.isMatch(loginRequest.password().getPasswordValue(), user.getPassword().getPasswordValue()))
 				.thenReturn(true);
 
 		// when
@@ -140,7 +139,7 @@ class UserServiceTest {
 
 		// then
 		verify(userRepository).findByLoginId(loginRequest.loginId());
-		verify(passwordEncoder).isMatch(loginRequest.password(), user.getPassword());
+		verify(passwordEncoder).isMatch(loginRequest.password().getPasswordValue(), user.getPassword().getPasswordValue());
 
 		assertThat(result).usingRecursiveComparison()
 				.ignoringFields("userId")
@@ -170,11 +169,12 @@ class UserServiceTest {
 		// given
 		Email email = new Email("email@email.com");
 		LoginRequest loginRequest = createLoginRequest();
-		User user = createUser(email, loginRequest.loginId(), "mismatchPassword");
+		Password mismatchPassword = new Password("mismatchPassword");
+		User user = createUser(email, loginRequest.loginId(), mismatchPassword);
 
 		when(userRepository.findByLoginId(loginRequest.loginId()))
 				.thenReturn(Optional.of(user));
-		when(passwordEncoder.isMatch(loginRequest.password(), user.getPassword()))
+		when(passwordEncoder.isMatch(loginRequest.password().getPasswordValue(), user.getPassword().getPasswordValue()))
 				.thenReturn(false);
 
 		// when, hen
@@ -183,6 +183,6 @@ class UserServiceTest {
 				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.LOGIN_FAIL);
 
 		verify(userRepository).findByLoginId(loginRequest.loginId());
-		verify(passwordEncoder).isMatch(loginRequest.password(), user.getPassword());
+		verify(passwordEncoder).isMatch(loginRequest.password().getPasswordValue(), user.getPassword().getPasswordValue());
 	}
 }

--- a/src/test/java/com/kongtoon/utils/TestUtil.java
+++ b/src/test/java/com/kongtoon/utils/TestUtil.java
@@ -5,6 +5,7 @@ import com.kongtoon.domain.comic.model.*;
 import com.kongtoon.domain.comic.model.dto.request.ComicRequest;
 import com.kongtoon.domain.user.dto.request.LoginRequest;
 import com.kongtoon.domain.user.dto.request.SignupRequest;
+import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.model.UserAuthority;
 import org.springframework.mock.web.MockMultipartFile;
@@ -19,7 +20,7 @@ public class TestUtil {
 
 	public static SignupRequest createSignupRequest() {
 		return new SignupRequest(
-				"loginId",
+				new LoginId("loginId"),
 				"Name",
 				"email@email.com",
 				"nickname",
@@ -27,7 +28,7 @@ public class TestUtil {
 		);
 	}
 
-	public static SignupRequest createSignupRequest(String loginId, String email) {
+	public static SignupRequest createSignupRequest(LoginId loginId, String email) {
 		return new SignupRequest(
 				loginId,
 				"Name",
@@ -37,7 +38,7 @@ public class TestUtil {
 		);
 	}
 
-	public static User createUser(String email, String loginId) {
+	public static User createUser(String email, LoginId loginId) {
 		return new User(
 				loginId,
 				"Name",
@@ -49,7 +50,7 @@ public class TestUtil {
 		);
 	}
 
-	public static User createUser(String email, String loginId, String password) {
+	public static User createUser(String email, LoginId loginId, String password) {
 		return new User(
 				loginId,
 				"Name",
@@ -63,7 +64,7 @@ public class TestUtil {
 
 	public static User createUser(UserAuthority userAuthority) {
 		return new User(
-				"loginId",
+				new LoginId("loginId"),
 				"Name",
 				"email@email.com",
 				"nickname",
@@ -75,7 +76,7 @@ public class TestUtil {
 
 	public static LoginRequest createLoginRequest() {
 		return new LoginRequest(
-				"loginId", "password"
+				new LoginId("loginId"), "password"
 		);
 	}
 

--- a/src/test/java/com/kongtoon/utils/TestUtil.java
+++ b/src/test/java/com/kongtoon/utils/TestUtil.java
@@ -5,10 +5,7 @@ import com.kongtoon.domain.comic.model.*;
 import com.kongtoon.domain.comic.model.dto.request.ComicRequest;
 import com.kongtoon.domain.user.dto.request.LoginRequest;
 import com.kongtoon.domain.user.dto.request.SignupRequest;
-import com.kongtoon.domain.user.model.Email;
-import com.kongtoon.domain.user.model.LoginId;
-import com.kongtoon.domain.user.model.User;
-import com.kongtoon.domain.user.model.UserAuthority;
+import com.kongtoon.domain.user.model.*;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.mock.web.MockPart;
 import org.springframework.web.multipart.MultipartFile;
@@ -25,7 +22,7 @@ public class TestUtil {
 				"Name",
 				new Email("email@email.com"),
 				"nickname",
-				"password123!"
+				new Password("password123!")
 		);
 	}
 
@@ -35,7 +32,7 @@ public class TestUtil {
 				"Name",
 				email,
 				"nickname",
-				"password123!"
+				new Password("password123!")
 		);
 	}
 
@@ -45,13 +42,13 @@ public class TestUtil {
 				"Name",
 				email,
 				"nickname",
-				"password123!",
+				new Password("password123!"),
 				UserAuthority.USER,
 				true
 		);
 	}
 
-	public static User createUser(Email email, LoginId loginId, String password) {
+	public static User createUser(Email email, LoginId loginId, Password password) {
 		return new User(
 				loginId,
 				"Name",
@@ -69,7 +66,7 @@ public class TestUtil {
 				"Name",
 				new Email("email@email.com"),
 				"nickname",
-				"password",
+				new Password("password123!"),
 				userAuthority,
 				true
 		);
@@ -77,7 +74,7 @@ public class TestUtil {
 
 	public static LoginRequest createLoginRequest() {
 		return new LoginRequest(
-				new LoginId("loginId"), "password"
+				new LoginId("loginId"), new Password("password123!")
 		);
 	}
 

--- a/src/test/java/com/kongtoon/utils/TestUtil.java
+++ b/src/test/java/com/kongtoon/utils/TestUtil.java
@@ -5,6 +5,7 @@ import com.kongtoon.domain.comic.model.*;
 import com.kongtoon.domain.comic.model.dto.request.ComicRequest;
 import com.kongtoon.domain.user.dto.request.LoginRequest;
 import com.kongtoon.domain.user.dto.request.SignupRequest;
+import com.kongtoon.domain.user.model.Email;
 import com.kongtoon.domain.user.model.LoginId;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.user.model.UserAuthority;
@@ -22,13 +23,13 @@ public class TestUtil {
 		return new SignupRequest(
 				new LoginId("loginId"),
 				"Name",
-				"email@email.com",
+				new Email("email@email.com"),
 				"nickname",
 				"password123!"
 		);
 	}
 
-	public static SignupRequest createSignupRequest(LoginId loginId, String email) {
+	public static SignupRequest createSignupRequest(LoginId loginId, Email email) {
 		return new SignupRequest(
 				loginId,
 				"Name",
@@ -38,7 +39,7 @@ public class TestUtil {
 		);
 	}
 
-	public static User createUser(String email, LoginId loginId) {
+	public static User createUser(Email email, LoginId loginId) {
 		return new User(
 				loginId,
 				"Name",
@@ -50,7 +51,7 @@ public class TestUtil {
 		);
 	}
 
-	public static User createUser(String email, LoginId loginId, String password) {
+	public static User createUser(Email email, LoginId loginId, String password) {
 		return new User(
 				loginId,
 				"Name",
@@ -66,7 +67,7 @@ public class TestUtil {
 		return new User(
 				new LoginId("loginId"),
 				"Name",
-				"email@email.com",
+				new Email("email@email.com"),
 				"nickname",
 				"password",
 				userAuthority,


### PR DESCRIPTION
closed #108 

- 중복 로직 제거
  - LoginId와 관련된 로직이 LoginId 클래스 내부에 정의된다.
- 명확한 의미 전달
  - 애매한 변수나 파라미터 명이 아닌 클래스 명으로 어떤 책임을 가지는지 명확하게 알 수 있다.
- User 객체의 책임 분산 및 LoginId 객체의 응집도 증가
  - 만약 로그인 ID의 길이를 반환하는 기능이 있다고 하자. 로그인 ID를 String으로 관리한다면 User나 서비스 레이어에서 해당 기능을 구현할 수 있다. User에서 구현한다면 User가 가지는 책임이 많아진다. 서비스 레이어에서 구현한다면 로그인 ID의 길이를 반환하는 기능이 여러 서비스 레이어에서 필요한 경우, 서비스 레이어마다 중복적으로 코드를 작성해줘야 한다. 이를 LoginId 객체 내부에서 관리함으로써 User 객체의 책임을 분산하고, LoginId 객체의 응집도를 증가시킬 수 있다.