### PR TITLE
#117: 너무 큰 메소드 분리, 메소드 이름 일부 수정

### DIFF
--- a/src/main/java/com/kongtoon/domain/author/controller/AuthorController.java
+++ b/src/main/java/com/kongtoon/domain/author/controller/AuthorController.java
@@ -39,7 +39,7 @@ public class AuthorController {
 	@LoginCheck(authority = UserAuthority.USER)
 	@GetMapping("/{authorId}")
 	public ResponseEntity<AuthorResponse> getAuthor(@PathVariable @Positive Long authorId) {
-		AuthorResponse authorResponse = authorService.getAuthor(authorId);
+		AuthorResponse authorResponse = authorService.getAuthorResponse(authorId);
 
 		return ResponseEntity.ok(authorResponse);
 	}


### PR DESCRIPTION
- 코드 가독성을 위함
- "객체지향 생활체조 원칙 1: 한 메서드에 오직 한 단계의 들여쓰기만 한다." 를 참고했습니다.