### PR TITLE
#128: 스케줄러를 사용하여 메모리에 저장된 조회 데이터 주기적으로 DB에 반영하는 기능 추가

### DIFF
--- a/src/main/java/com/kongtoon/common/scheduler/ViewCacheDataSyncScheduler.java
+++ b/src/main/java/com/kongtoon/common/scheduler/ViewCacheDataSyncScheduler.java
@@ -1,0 +1,27 @@
+package com.kongtoon.common.scheduler;
+
+import com.kongtoon.domain.view.repository.cache.ViewCache;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ViewCacheDataSyncScheduler {
+
+    private final ViewCache viewCache;
+
+    @Transactional
+    @Scheduled(cron = "0 */30 * * * *")
+    public void batchInsertAndUpdateToDB() {
+        log.info("ViewCache 데이터 DB 반영 스케줄링 시작");
+
+        viewCache.batchInsertToDB();
+        viewCache.batchUpdateToDB();
+
+        log.info("ViewCache 데이터 DB 반영 스케줄링 종료");
+    }
+}

--- a/src/main/java/com/kongtoon/domain/view/repository/cache/ViewCache.java
+++ b/src/main/java/com/kongtoon/domain/view/repository/cache/ViewCache.java
@@ -29,4 +29,8 @@ public interface ViewCache {
     boolean checkInsert();
 
     boolean checkUpdate();
+
+    void batchInsertToDB();
+
+    void batchUpdateToDB();
 }

--- a/src/main/java/com/kongtoon/domain/view/repository/cache/ViewMapCache.java
+++ b/src/main/java/com/kongtoon/domain/view/repository/cache/ViewMapCache.java
@@ -71,6 +71,18 @@ public class ViewMapCache implements ViewCache {
                 .size() >= LIMIT_SIZE;
     }
 
+    @Override
+    public synchronized void batchInsertToDB() {
+        viewJdbcRepository.batchInsert(getValues(ViewCache.INSERT_MAP_MAIN_KEY));
+        clear(ViewCache.INSERT_MAP_MAIN_KEY);
+    }
+
+    @Override
+    public synchronized void batchUpdateToDB() {
+        viewJdbcRepository.batchUpdate(getValues(ViewCache.UPDATE_MAP_MAIN_KEY));
+        clear(ViewCache.UPDATE_MAP_MAIN_KEY);
+    }
+
     private void saveKeyInInsertMap(View view, String subKey, Map<String, View> viewsForInsert) {
         if (existsKey(INSERT_MAP_MAIN_KEY, subKey)) {
             View findView = viewsForInsert.get(subKey);

--- a/src/main/java/com/kongtoon/domain/view/service/event/EpisodeViewedEventListener.java
+++ b/src/main/java/com/kongtoon/domain/view/service/event/EpisodeViewedEventListener.java
@@ -3,7 +3,6 @@ package com.kongtoon.domain.view.service.event;
 import com.kongtoon.domain.episode.model.Episode;
 import com.kongtoon.domain.user.model.User;
 import com.kongtoon.domain.view.model.View;
-import com.kongtoon.domain.view.repository.ViewJdbcRepository;
 import com.kongtoon.domain.view.repository.ViewRepository;
 import com.kongtoon.domain.view.repository.cache.ViewCache;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +14,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class EpisodeViewedEventListener {
 
-	private final ViewJdbcRepository viewJdbcRepository;
 	private final ViewCache viewCache;
 	private final ViewRepository viewRepository;
 
@@ -44,15 +42,13 @@ public class EpisodeViewedEventListener {
 
 	private void checkAndBulkUpdate() {
 		if (viewCache.checkUpdate()) {
-			viewJdbcRepository.batchUpdate(viewCache.getValues(ViewCache.UPDATE_MAP_MAIN_KEY));
-			viewCache.clear(ViewCache.UPDATE_MAP_MAIN_KEY);
+			viewCache.batchUpdateToDB();
 		}
 	}
 
 	private void checkAndBulkInsert() {
 		if (viewCache.checkInsert()) {
-			viewJdbcRepository.batchInsert(viewCache.getValues(ViewCache.INSERT_MAP_MAIN_KEY));
-			viewCache.clear(ViewCache.INSERT_MAP_MAIN_KEY);
+			viewCache.batchInsertToDB();
 		}
 	}
 }


### PR DESCRIPTION
- 30분 마다 메모리에 저장된 조회 데이터가 DB에 반영되도록 변경했습니다.
- 이때 `synchronized` 키워드를 통해 조회 데이터의 개수가 5000개 이상일 때 DB에 반영할 되는 로직과 스케줄러를 통해 DB에 반영되는 로직이 동시에 수행될 때 데이터가 중복되지 않도록 하였습니다.